### PR TITLE
docs: clarify that OWNER/REPO format defaults to gitcode.com

### DIFF
--- a/src/gitcode_cli/cli.py
+++ b/src/gitcode_cli/cli.py
@@ -13,7 +13,7 @@ from .errors import GCError
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(version=__version__, prog_name="gc")
-@click.option("--repo", "repo_name", "-R", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("--repo", "repo_name", "-R", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.option("--token", hidden=True, help="Override authentication token.")
 @click.pass_context
 def main(ctx: click.Context, repo_name: str | None, token: str | None) -> None:

--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -21,7 +21,7 @@ def issue_group() -> None:
 
 
 @issue_group.command("list")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.option("-s", "--state")
 @click.option("-l", "--label", "labels", multiple=True)
 @click.option("-A", "--author")
@@ -81,7 +81,7 @@ def issue_list(
 
 
 @issue_group.command("view")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.argument("identifier")
 @click.option("-w", "--web", is_flag=True, help="Open the issue in the web browser.")
 @click.option("-c", "--comments", is_flag=True, help="View issue comments.")
@@ -142,7 +142,7 @@ def issue_view(
 
 
 @issue_group.command("create")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.option("-t", "--title")
 @click.option("-b", "--body")
 @click.option("-a", "--assignee")
@@ -188,7 +188,7 @@ def issue_create(
 
 
 @issue_group.command("close")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.argument("identifier")
 @click.pass_context
 def issue_close(ctx: click.Context, repo_name: str | None, identifier: str) -> None:
@@ -205,7 +205,7 @@ def issue_close(ctx: click.Context, repo_name: str | None, identifier: str) -> N
 
 
 @issue_group.command("comment")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.argument("identifier")
 @click.option("-b", "--body")
 @click.option("-F", "--body-file")
@@ -239,7 +239,7 @@ def issue_comment(
 
 
 @issue_group.command("reopen")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.argument("identifier")
 @click.pass_context
 def issue_reopen(ctx: click.Context, repo_name: str | None, identifier: str) -> None:
@@ -256,7 +256,7 @@ def issue_reopen(ctx: click.Context, repo_name: str | None, identifier: str) -> 
 
 
 @issue_group.command("edit")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.argument("identifier")
 @click.option("-t", "--title")
 @click.option("-b", "--body")
@@ -303,7 +303,7 @@ def issue_edit(
 
 
 @issue_group.command("delete")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.argument("identifier")
 @click.confirmation_option(prompt="Are you sure you want to delete this issue?")
 @click.pass_context
@@ -321,7 +321,7 @@ def issue_delete(ctx: click.Context, repo_name: str | None, identifier: str) -> 
 
 
 @issue_group.command("status")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.pass_context
 def issue_status(ctx: click.Context, repo_name: str | None) -> None:
     app = ctx.obj["app"]

--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -24,7 +24,7 @@ def pr_group() -> None:
 
 
 @pr_group.command("list")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.option("-s", "--state")
 @click.option("-A", "--author")
 @click.option("-B", "--base")
@@ -93,7 +93,7 @@ def pr_list(
 
 
 @pr_group.command("view")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.argument("identifier", required=False)
 @click.option("-w", "--web", is_flag=True, help="Open the pull request in the web browser.")
 @click.option("--json", "json_fields", help="Output JSON. Optionally specify comma-separated fields.")
@@ -129,7 +129,7 @@ def pr_view(
 
 
 @pr_group.command("create")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.option("-t", "--title")
 @click.option("-b", "--body")
 @click.option("-F", "--body-file")
@@ -228,7 +228,7 @@ def pr_create(
 
 
 @pr_group.command("close")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.argument("identifier", required=False)
 @click.option("-c", "--comment")
 @click.option("-d", "--delete-branch", is_flag=True, help="Delete the remote branch after closing.")
@@ -259,7 +259,7 @@ def pr_close(
 
 
 @pr_group.command("merge")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.argument("identifier", required=False)
 @click.option("-m", "--merge", "merge_mode", flag_value="merge")
 @click.option("-s", "--squash", "merge_mode", flag_value="squash")
@@ -277,7 +277,7 @@ def pr_merge(ctx: click.Context, repo_name: str | None, identifier: str | None, 
 
 
 @pr_group.command("comment")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.argument("identifier", required=False)
 @click.option("-b", "--body")
 @click.option("--path")
@@ -303,7 +303,7 @@ def pr_comment(
 
 
 @pr_group.command("review")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.argument("identifier", required=False)
 @click.option("-a", "--approve", is_flag=True, help="Approve the pull request. GitCode maps this to its review API.")
 @click.option("--body")
@@ -350,7 +350,7 @@ def pr_review(
 
 
 @pr_group.command("reopen")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.argument("identifier", required=False)
 @click.pass_context
 def pr_reopen(ctx: click.Context, repo_name: str | None, identifier: str | None) -> None:
@@ -365,7 +365,7 @@ def pr_reopen(ctx: click.Context, repo_name: str | None, identifier: str | None)
 
 
 @pr_group.command("edit")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.argument("identifier", required=False)
 @click.option("-t", "--title")
 @click.option("-b", "--body")
@@ -419,7 +419,7 @@ def pr_edit(
 
 
 @pr_group.command("diff")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.argument("identifier", required=False)
 @click.pass_context
 def pr_diff(ctx: click.Context, repo_name: str | None, identifier: str | None) -> None:
@@ -433,7 +433,7 @@ def pr_diff(ctx: click.Context, repo_name: str | None, identifier: str | None) -
 
 
 @pr_group.command("checkout")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.argument("identifier", required=False)
 @click.option("-b", "--branch", help="Local branch name to checkout into.")
 @click.pass_context
@@ -457,7 +457,7 @@ def pr_checkout(ctx: click.Context, repo_name: str | None, identifier: str | Non
 
 
 @pr_group.command("ready")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.argument("identifier", required=False)
 @click.option("--undo", is_flag=True, help="Convert a pull request to draft.")
 @click.pass_context
@@ -475,7 +475,7 @@ def pr_ready(ctx: click.Context, repo_name: str | None, identifier: str | None, 
 
 
 @pr_group.command("status")
-@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.pass_context
 def pr_status(ctx: click.Context, repo_name: str | None) -> None:
     app = ctx.obj["app"]


### PR DESCRIPTION
## Description

Update the `-R/--repo` option help text to clearly indicate that the `OWNER/REPO` format defaults to `gitcode.com`, matching the behavior of GitHub CLI (`gh`) which defaults to `github.com`.

This addresses user confusion about needing to specify the full `HOST/OWNER/REPO` format when `OWNER/REPO` already works and is the recommended usage pattern.

## Related Issue

Closes #2

## Type of Change

- [x] Documentation update

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/`)
- [x] Format passes (`python -m ruff format --check src/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide