### PR TITLE
fix: add stable required CI test check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,15 @@ jobs:
           files: ./coverage.xml
           fail_ci_if_error: false
 
+  tests-passed:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Confirm test matrix passed
+        run: echo "All test matrix jobs passed"
+
   lint:
     name: Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Add a stable `Test` check job that depends on the full Python matrix so branch protection can require a check name that always exists.

## Related Issue

Fixes #5

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [x] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [ ] I have added tests that prove my fix/feature works
- [ ] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide