### PR TITLE
release: bump version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygitcode"
-version = "0.1.0"
+version = "0.1.1"
 description = "A CLI tool for GitCode (api.gitcode.com), modeled after GitHub CLI."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump package version from 0.1.0 to 0.1.1
- verify the 0.1.1 sdist and wheel build locally
- run twine check for the 0.1.1 distributions

## Test plan
- [x] conda run -n pt-snap python -m build
- [x] conda run -n pt-snap python -m twine check dist/pygitcode-0.1.1.tar.gz dist/pygitcode-0.1.1-py3-none-any.whl