### PR TITLE
fix: prevent KeyError when API response lacks number field

### DIFF
--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -6,7 +6,7 @@ from ..cli_compat import get_body_from_options, normalize_multi_values
 from ..formatters import format_issue_detail, format_issue_list, output_result
 from ..repo import resolve_repo
 from ..services import IssueService
-from ..utils import open_in_browser, prompt_if_missing, read_body_file, resolve_issue_arg
+from ..utils import open_in_browser, prompt_if_missing, read_body_file, resolve_issue_arg, safe_number
 
 
 def _echo_issue_summary(items: list[dict]) -> None:
@@ -217,7 +217,7 @@ def issue_close(
     if reason:
         update_data["state_reason"] = reason
     item = service.update(owner, repo, number, **update_data)
-    click.echo(f"Closed issue #{item['number']}")
+    click.echo(f"Closed issue #{safe_number(item, number)}")
 
 
 @issue_group.command("comment")
@@ -268,7 +268,7 @@ def issue_reopen(ctx: click.Context, repo_name: str | None, identifier: str) -> 
         owner, repo = resolve_repo(repo_name or app.repo)
     service = IssueService(app.client())
     item = service.update(owner, repo, number, state="open")
-    click.echo(f"Reopened issue #{item['number']}")
+    click.echo(f"Reopened issue #{safe_number(item, number)}")
 
 
 @issue_group.command("edit")
@@ -326,7 +326,7 @@ def issue_edit(
         raise click.UsageError("must specify at least one field to edit")
     service = IssueService(app.client())
     item = service.update(owner, repo, number, **data)
-    click.echo(f"Edited issue #{item['number']}")
+    click.echo(f"Edited issue #{safe_number(item, number)}")
 
 
 @issue_group.command("delete")
@@ -358,7 +358,7 @@ def issue_status(ctx: click.Context, repo_name: str | None) -> None:
     click.echo("GitCode-limited approximation of gh issue status")
     click.echo(f"Repository open issues for {owner}/{repo}:")
     for item in items:
-        click.echo(f"  #{item['number']}\t{item['state']}\t{item['title']}")
+        click.echo(f"  #{safe_number(item, '?')}\t{item['state']}\t{item['title']}")
 
 
 issue_group.add_command(issue_list, name="ls")

--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -15,7 +15,14 @@ from ..cli_compat import (
 from ..formatters import format_pr_detail, format_pr_list, output_result
 from ..repo import resolve_repo
 from ..services import PullRequestService
-from ..utils import get_current_git_branch, open_in_browser, prompt_if_missing, read_body_file, resolve_pr_arg
+from ..utils import (
+    get_current_git_branch,
+    open_in_browser,
+    prompt_if_missing,
+    read_body_file,
+    resolve_pr_arg,
+    safe_number,
+)
 
 
 @click.group("pr")
@@ -277,7 +284,7 @@ def pr_close(
                 click.echo("Warning: could not determine branch to delete.", err=True)
         except Exception as exc:
             click.echo(f"Warning: could not delete remote branch: {exc}", err=True)
-    click.echo(f"Closed pull request #{item['number']}")
+    click.echo(f"Closed pull request #{safe_number(item, number)}")
 
 
 @pr_group.command("merge")
@@ -412,7 +419,7 @@ def pr_reopen(ctx: click.Context, repo_name: str | None, identifier: str | None)
     owner, repo, number = resolve_pr_arg(resolved_identifier, owner, repo, service)
     number = int(number)
     item = service.update(owner, repo, number, state="open")
-    click.echo(f"Reopened pull request #{item['number']}")
+    click.echo(f"Reopened pull request #{safe_number(item, number)}")
 
 
 @pr_group.command("edit")
@@ -477,7 +484,7 @@ def pr_edit(
     if not data:
         raise click.UsageError("must specify at least one field to edit")
     item = service.update(owner, repo, number, **data)
-    click.echo(f"Edited pull request #{item['number']}")
+    click.echo(f"Edited pull request #{safe_number(item, number)}")
 
 
 @pr_group.command("diff")
@@ -531,9 +538,9 @@ def pr_ready(ctx: click.Context, repo_name: str | None, identifier: str | None, 
     owner, repo, number = resolve_pr_arg(resolved_identifier, owner, repo, service)
     item = service.update(owner, repo, int(number), draft=undo)
     if undo:
-        click.echo(f"Converted pull request #{item['number']} to draft")
+        click.echo(f"Converted pull request #{safe_number(item, number)} to draft")
     else:
-        click.echo(f"Marked pull request #{item['number']} as ready for review")
+        click.echo(f"Marked pull request #{safe_number(item, number)} as ready for review")
 
 
 @pr_group.command("status")
@@ -549,7 +556,7 @@ def pr_status(ctx: click.Context, repo_name: str | None) -> None:
     )
     if items:
         for item in items:
-            click.echo(f"  #{item['number']}\t{item['state']}\t{item['title']}")
+            click.echo(f"  #{safe_number(item, '?')}\t{item['state']}\t{item['title']}")
     else:
         click.echo("  No open pull requests")
 

--- a/src/gitcode_cli/utils.py
+++ b/src/gitcode_cli/utils.py
@@ -61,7 +61,12 @@ def open_in_browser(url: str) -> None:
 
 
 def safe_number(item: Any, fallback: int | str) -> int | str:
-    return (item or {}).get("number") or (item or {}).get("iid") or fallback
+    if isinstance(item, dict):
+        if "number" in item and item["number"] is not None:
+            return item["number"]
+        if "iid" in item and item["iid"] is not None:
+            return item["iid"]
+    return fallback
 
 
 # --- Issue / PR identifier resolvers ---

--- a/src/gitcode_cli/utils.py
+++ b/src/gitcode_cli/utils.py
@@ -4,7 +4,7 @@ import re
 import subprocess
 import webbrowser
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import click
 
@@ -58,6 +58,10 @@ def read_body_file(path: str) -> str:
 def open_in_browser(url: str) -> None:
     """Open URL in default browser."""
     webbrowser.open(url)
+
+
+def safe_number(item: Any, fallback: int | str) -> int | str:
+    return (item or {}).get("number") or (item or {}).get("iid") or fallback
 
 
 # --- Issue / PR identifier resolvers ---

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -269,6 +269,18 @@ class TestIssueClose:
         assert result.exit_code == 0
         mock_client.patch.assert_called_once()
 
+    def test_close_without_number_in_response(self, runner, mock_client, mock_repo):
+        mock_client.patch.return_value = {"iid": "42", "state": "closed"}
+        result = runner.invoke(main, ["issue", "close", "42"])
+        assert result.exit_code == 0
+        assert "Closed issue #42" in result.output
+
+    def test_close_without_number_or_iid_in_response(self, runner, mock_client, mock_repo):
+        mock_client.patch.return_value = {"state": "closed"}
+        result = runner.invoke(main, ["issue", "close", "42"])
+        assert result.exit_code == 0
+        assert "Closed issue #42" in result.output
+
 
 class TestIssueComment:
     def test_default(self, runner, mock_client, mock_repo):
@@ -317,6 +329,12 @@ class TestIssueReopen:
         result = runner.invoke(main, ["issue", "reopen", "https://gitcode.com/owner/repo/issues/42"])
         assert result.exit_code == 0
 
+    def test_reopen_without_number_in_response(self, runner, mock_client, mock_repo):
+        mock_client.patch.return_value = {"iid": "42", "state": "open"}
+        result = runner.invoke(main, ["issue", "reopen", "42"])
+        assert result.exit_code == 0
+        assert "Reopened issue #42" in result.output
+
 
 class TestIssueEdit:
     def test_default(self, runner, mock_client, mock_repo):
@@ -343,6 +361,12 @@ class TestIssueEdit:
     def test_url(self, runner, mock_client):
         result = runner.invoke(main, ["issue", "edit", "https://gitcode.com/owner/repo/issues/42", "-t", "New"])
         assert result.exit_code == 0
+
+    def test_edit_without_number_in_response(self, runner, mock_client, mock_repo):
+        mock_client.patch.return_value = {"iid": "42", "title": "New"}
+        result = runner.invoke(main, ["issue", "edit", "42", "-t", "New"])
+        assert result.exit_code == 0
+        assert "Edited issue #42" in result.output
 
 
 class TestIssueDelete:

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -386,6 +386,18 @@ class TestPrClose:
         assert "Delete the remote branch after closing." in result.output
         assert "Delete the local and remote branch after closing." not in result.output
 
+    def test_pr_close_without_number_in_response(self, runner, mock_client, mock_repo):
+        mock_client.patch.return_value = {"iid": 42, "head": {"ref": "feature"}}
+        result = runner.invoke(main, ["pr", "close", "42"])
+        assert result.exit_code == 0
+        assert "Closed pull request #42" in result.output
+
+    def test_pr_close_without_number_or_iid_in_response(self, runner, mock_client, mock_repo):
+        mock_client.patch.return_value = {"state": "closed", "head": {"ref": "feature"}}
+        result = runner.invoke(main, ["pr", "close", "42"])
+        assert result.exit_code == 0
+        assert "Closed pull request #42" in result.output
+
 
 class TestPrMerge:
     def test_pr_merge(self, runner, mock_client, mock_repo):
@@ -502,6 +514,12 @@ class TestPrReopen:
         assert result.exit_code == 0
         assert "Reopened pull request #42" in result.output
 
+    def test_pr_reopen_without_number_in_response(self, runner, mock_client, mock_repo):
+        mock_client.patch.return_value = {"iid": 42}
+        result = runner.invoke(main, ["pr", "reopen", "42"])
+        assert result.exit_code == 0
+        assert "Reopened pull request #42" in result.output
+
 
 class TestPrEdit:
     def test_pr_edit(self, runner, mock_client, mock_repo):
@@ -511,6 +529,12 @@ class TestPrEdit:
         assert "Edited pull request #42" in result.output
         assert mock_client.patch.call_args.kwargs["json"]["title"] == "New"
         assert mock_client.patch.call_args.kwargs["json"]["base"] == "develop"
+
+    def test_pr_edit_without_number_in_response(self, runner, mock_client, mock_repo):
+        mock_client.patch.return_value = {"iid": 42}
+        result = runner.invoke(main, ["pr", "edit", "42", "-t", "New"])
+        assert result.exit_code == 0
+        assert "Edited pull request #42" in result.output
 
 
 class TestPrStatus:
@@ -570,6 +594,18 @@ class TestPrReady:
         result = runner.invoke(main, ["pr", "ready", "42"])
         assert result.exit_code == 0
         assert "Marked pull request #42 as ready for review" in result.output
+
+    def test_pr_ready_without_number_in_response(self, runner, mock_client, mock_repo):
+        mock_client.patch.return_value = {"iid": 42}
+        result = runner.invoke(main, ["pr", "ready", "42"])
+        assert result.exit_code == 0
+        assert "Marked pull request #42 as ready for review" in result.output
+
+    def test_pr_ready_undo_without_number_in_response(self, runner, mock_client, mock_repo):
+        mock_client.patch.return_value = {"iid": 42}
+        result = runner.invoke(main, ["pr", "ready", "42", "--undo"])
+        assert result.exit_code == 0
+        assert "Converted pull request #42 to draft" in result.output
 
 
 class TestPrCreateEdgeCases:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -16,6 +16,7 @@ from gitcode_cli.utils import (
     read_body_file,
     resolve_issue_arg,
     resolve_pr_arg,
+    safe_number,
 )
 
 
@@ -158,3 +159,23 @@ class TestResolvePrArg:
             "repo",
             "42",
         )
+
+
+class TestSafeNumber:
+    def test_returns_number_when_present(self):
+        assert safe_number({"number": 42, "iid": 1}, 99) == 42
+
+    def test_returns_iid_when_number_missing(self):
+        assert safe_number({"iid": 1}, 99) == 1
+
+    def test_returns_fallback_when_both_missing(self):
+        assert safe_number({"state": "closed"}, 42) == 42
+
+    def test_returns_fallback_when_empty_dict(self):
+        assert safe_number({}, 42) == 42
+
+    def test_prefers_number_over_iid(self):
+        assert safe_number({"number": 10, "iid": 20}, 99) == 10
+
+    def test_string_fallback(self):
+        assert safe_number({}, "?") == "?"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -179,3 +179,21 @@ class TestSafeNumber:
 
     def test_string_fallback(self):
         assert safe_number({}, "?") == "?"
+
+    def test_number_zero_is_not_falsy(self):
+        assert safe_number({"number": 0, "iid": 5}, 99) == 0
+
+    def test_iid_zero_is_not_falsy(self):
+        assert safe_number({"iid": 0}, 99) == 0
+
+    def test_number_none_falls_through_to_iid(self):
+        assert safe_number({"number": None, "iid": 7}, 99) == 7
+
+    def test_both_none_returns_fallback(self):
+        assert safe_number({"number": None, "iid": None}, 99) == 99
+
+    def test_non_dict_item_returns_fallback(self):
+        assert safe_number(None, 42) == 42
+
+    def test_string_item_returns_fallback(self):
+        assert safe_number("not a dict", 42) == 42


### PR DESCRIPTION
## Description

Add `safe_number()` helper to `utils.py` that safely extracts PR/Issue number from API responses with fallback chain: `number` → `iid` → `fallback`. Replace all `item['number']` hard-coded accesses in `pr.py` and `issue.py` with `safe_number()` calls.

## Related Issue

Closes #12

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90% (91.76%)

### New test cases added:
- `TestSafeNumber` — 6 tests covering all `safe_number` branches
- `TestPrClose` — 2 tests for missing `number` in response
- `TestPrReopen` — 1 test for missing `number` in response
- `TestPrEdit` — 1 test for missing `number` in response
- `TestPrReady` — 2 tests for missing `number` in response
- `TestIssueClose` — 2 tests for missing `number` in response
- `TestIssueReopen` — 1 test for missing `number` in response
- `TestIssueEdit` — 1 test for missing `number` in response

## Checklist

- [x] My code follows the project coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] My changes generate no new lint/type warnings
