### PR TITLE
fix: prevent KeyError when pr create response lacks html_url

### DIFF
--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -245,7 +245,9 @@ def pr_create(
         json_fields,
         jq_query,
         template,
-        default_formatter=lambda data: click.echo(data["html_url"]),
+        default_formatter=lambda data: click.echo(
+            data.get("html_url") or data.get("url") or f"Created PR #{data.get('number', '?')}"
+        ),
     )
 
 

--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -246,7 +246,9 @@ def pr_create(
         jq_query,
         template,
         default_formatter=lambda data: click.echo(
-            data.get("html_url") or data.get("url") or f"Created PR #{data.get('number', '?')}"
+            data.get("html_url")
+            or data.get("url")
+            or (f"Created PR #{data['number']}" if "number" in data else "Created pull request")
         ),
     )
 

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -661,3 +661,12 @@ class TestPrCreateMissingHtmlUrl:
         )
         assert result.exit_code == 0
         assert "https://example.com/42" in result.output
+
+    def test_pr_create_missing_all_url_fields_falls_back_to_generic_message(self, runner, mock_client, mock_repo):
+        mock_client.post.return_value = {"title": "Test"}
+        result = runner.invoke(
+            main,
+            ["pr", "create", "--title", "Test", "--body", "Body", "--base", "master", "--head", "feature"],
+        )
+        assert result.exit_code == 0
+        assert "Created pull request" in result.output

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -632,3 +632,32 @@ class TestPrCheckoutEdgeCases:
             result = runner.invoke(main, ["pr", "checkout", "42"])
             assert result.exit_code != 0
             assert "Git checkout failed" in result.output
+
+
+class TestPrCreateMissingHtmlUrl:
+    def test_pr_create_missing_html_url_falls_back_to_url(self, runner, mock_client, mock_repo):
+        mock_client.post.return_value = {"number": 42, "url": "https://api.example.com/42", "title": "Test"}
+        result = runner.invoke(
+            main,
+            ["pr", "create", "--title", "Test", "--body", "Body", "--base", "master", "--head", "feature"],
+        )
+        assert result.exit_code == 0
+        assert "https://api.example.com/42" in result.output
+
+    def test_pr_create_missing_html_url_and_url_falls_back_to_number(self, runner, mock_client, mock_repo):
+        mock_client.post.return_value = {"number": 42, "title": "Test"}
+        result = runner.invoke(
+            main,
+            ["pr", "create", "--title", "Test", "--body", "Body", "--base", "master", "--head", "feature"],
+        )
+        assert result.exit_code == 0
+        assert "Created PR #42" in result.output
+
+    def test_pr_create_with_html_url_unchanged(self, runner, mock_client, mock_repo):
+        mock_client.post.return_value = {"number": 42, "html_url": "https://example.com/42", "title": "Test"}
+        result = runner.invoke(
+            main,
+            ["pr", "create", "--title", "Test", "--body", "Body", "--base", "master", "--head", "feature"],
+        )
+        assert result.exit_code == 0
+        assert "https://example.com/42" in result.output


### PR DESCRIPTION
## Description

Fix `gc pr create` crashing with `KeyError: 'html_url'` when the GitCode API response does not include the `html_url` field. The PR is successfully created, but the CLI crashes before displaying the result.

The `default_formatter` in `pr_create` now uses defensive dictionary access with a fallback chain: `html_url` → `url` → `Created PR #{number}` → `Created pull request`.

## Related Issue

Fixes #13

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

Added 3 new test cases:
- `test_pr_create_missing_html_url_falls_back_to_url`: verifies fallback to `url` field
- `test_pr_create_missing_html_url_and_url_falls_back_to_number`: verifies fallback to PR number
- `test_pr_create_with_html_url_unchanged`: verifies existing behavior is preserved

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide
