### PR TITLE
feat: tag-driven version management for PyPI releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,11 +13,21 @@ jobs:
       name: pypi
       url: https://pypi.org/p/pygitcode
     permissions:
-      id-token: write  # Required for trusted publishing
+      id-token: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Write version to __init__.py
+        run: |
+          sed -i 's/^__version__ = .*/__version__ = "'"${{ steps.version.outputs.VERSION }}"'"/' src/gitcode_cli/__init__.py
+          echo "Updated __init__.py:"
+          cat src/gitcode_cli/__init__.py
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygitcode"
-version = "0.1.1"
+dynamic = ["version"]
 description = "A CLI tool for GitCode (api.gitcode.com), modeled after GitHub CLI."
 readme = "README.md"
 license = "MIT"
@@ -57,6 +57,9 @@ gitcode = "gitcode_cli.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.dynamic]
+version = {attr = "gitcode_cli.__version__"}
 
 # --- pytest ---
 [tool.pytest.ini_options]

--- a/src/gitcode_cli/__init__.py
+++ b/src/gitcode_cli/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.1.0"
+__version__ = "0.0.0-dev"

--- a/src/gitcode_cli/cli.py
+++ b/src/gitcode_cli/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import importlib.metadata
 import sys
 
 import click
@@ -24,8 +25,15 @@ def _configure_stdout_encoding() -> None:
                 stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
 
 
+def _get_version() -> str:
+    try:
+        return importlib.metadata.version("pygitcode")
+    except importlib.metadata.PackageNotFoundError:
+        return __version__
+
+
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
-@click.version_option(version=__version__, prog_name="gitcode")
+@click.version_option(version=_get_version(), prog_name="gitcode")
 @click.option("--repo", "repo_name", "-R", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.option("--token", hidden=True, help="Override authentication token.")
 @click.pass_context
@@ -46,7 +54,7 @@ def process_result(*_args: object, **_kwargs: object) -> None:
 
 @main.command("version")
 def version_command() -> None:
-    safe_echo(f"gitcode version {__version__}")
+    safe_echo(f"gitcode version {_get_version()}")
 
 
 main.add_command(auth_group)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -17,7 +17,7 @@ class TestCli:
     def test_cli_version(self, runner):
         result = runner.invoke(main, ["version"])
         assert result.exit_code == 0
-        assert "gitcode version 0.1.0" in result.output
+        assert "gitcode version" in result.output
 
     def test_cli_help(self, runner):
         result = runner.invoke(main, ["--help"])


### PR DESCRIPTION
## Description

实现 tag 驱动的自动版本管理，打 tag 发布时无需手动修改 pyproject.toml。

### 变更内容

- pyproject.toml: 使用 dynamic = ["version"]，从 gitcode_cli.__version__ 动态读取版本号
- __init__.py: __version__ 设为 "0.0.0-dev" 作为开发占位版本
- cli.py: 通过 importlib.metadata.version("pygitcode") 读取已安装包版本，未安装时 fallback 到 __version__
- publish.yml: 新增步骤从 tag 提取版本号并写入 __init__.py，然后 build + publish
- test_cli.py: 移除硬编码版本号断言

### 发布流程（改造后）

打 tag v0.2.0-alpha -> 推送 tag -> CI 触发:
  1. Checkout 代码
  2. 从 tag 名提取版本号（去掉 v 前缀）-> "0.2.0-alpha"
  3. 写入 src/gitcode_cli/__init__.py 的 __version__
  4. python -m build
  5. Publish to PyPI

不再需要：修改 pyproject.toml -> 创建 release 分支 -> 提 PR -> 等合并 -> 打 tag

## Related Issue

N/A

## Type of Change

- [x] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (python -m pytest tests/unit/) - 250 passed
- [x] Lint passes (python -m ruff check src/ tests/)
- [x] Format passes (python -m ruff format --check src/ tests/)
- [x] Type check passes (python -m basedpyright src/)
- [x] Test coverage remains >= 90% (95.66%)
- [x] Local build succeeds (python -m build)
- [x] Twine check passes

## Checklist

- [x] My code follows the project coding style (ruff + black, line-length 120)
- [x] My changes generate no new lint/type warnings
- [x] I have updated the documentation if needed (release process doc updated locally)
