### PR TITLE
fix: correct version from 0.2.0 to 0.1.2a0 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2026-04-28
+## [0.1.2a0] - 2026-04-29
 
 ### Added
 


### PR DESCRIPTION
## Summary

将 CHANGELOG.md 中的版本号从 `0.2.0` 修正为 `0.1.2a0`。

## Reason

根据语义化版本规范，当前阶段的变更（新增子命令、修复 bug）属于增量迭代，应使用 `0.1.2a0`（alpha 预发布版本）而非直接跳到 `0.2.0`。这更准确地反映了当前项目的发展阶段。

## Changes

- `CHANGELOG.md`: `## [0.2.0] - 2026-04-28` → `## [0.1.2a0] - 2026-04-29`

README.md 中无硬编码版本号，无需修改。