### PR TITLE
fix: handle issue create boundary inputs

### DIFF
--- a/src/gitcode_cli/cli_compat.py
+++ b/src/gitcode_cli/cli_compat.py
@@ -10,6 +10,8 @@ from .utils import get_current_git_branch, get_default_git_branch, read_body_fil
 
 def get_body_from_options(body: str | None, body_file: str | None, editor: bool) -> str | None:
     """Resolve body text from inline text, file/stdin, or editor."""
+    if body is not None and body_file:
+        raise click.UsageError("cannot use --body and --body-file together")
     if body is not None:
         return body
     if body_file:

--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -174,8 +174,9 @@ def issue_create(
         open_in_browser(f"https://gitcode.com/{owner}/{repo}/issues/new")
         return
     title = prompt_if_missing(title, "Title")
-    if body_file:
-        body = read_body_file(body_file)
+    if len(title) > 255:
+        raise click.ClickException("title must be 255 characters or fewer")
+    body = get_body_from_options(body=body, body_file=body_file, editor=False)
     labels_str = normalize_multi_values(labels)
     service = IssueService(app.client())
     item = service.create(

--- a/src/gitcode_cli/utils.py
+++ b/src/gitcode_cli/utils.py
@@ -53,7 +53,10 @@ def get_default_git_branch() -> str | None:
 
 def read_body_file(path: str) -> str:
     """Read body content from a file."""
-    return Path(path).read_text(encoding="utf-8")
+    try:
+        return Path(path).read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise click.ClickException(f"Body file not found: {path}") from exc
 
 
 def open_in_browser(url: str) -> None:

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -230,6 +230,33 @@ class TestIssueView:
         assert result.exit_code == 0
         assert mock_client.post.call_args[1]["json"]["body"] == "file body content"
 
+    def test_reads_body_from_stdin_when_body_file_is_dash(self, runner, mock_client, mock_repo):
+        result = runner.invoke(main, ["issue", "create", "-t", "T", "-F", "-"], input="stdin body")
+        assert result.exit_code == 0
+        assert mock_client.post.call_args[1]["json"]["body"] == "stdin body"
+
+    def test_rejects_body_and_body_file_together(self, runner, mock_client, mock_repo, tmp_path):
+        body_file = tmp_path / "body.md"
+        body_file.write_text("file body content")
+        result = runner.invoke(main, ["issue", "create", "-t", "T", "-b", "inline", "-F", str(body_file)])
+        assert result.exit_code != 0
+        assert "cannot use --body and --body-file together" in result.output
+        mock_client.post.assert_not_called()
+
+    def test_missing_body_file_returns_click_error(self, runner, mock_client, mock_repo, tmp_path):
+        missing = tmp_path / "missing.md"
+        result = runner.invoke(main, ["issue", "create", "-t", "T", "-F", str(missing)])
+        assert result.exit_code != 0
+        assert "Body file not found" in result.output
+        mock_client.post.assert_not_called()
+
+    def test_rejects_title_longer_than_255_characters(self, runner, mock_client, mock_repo):
+        title = "T" * 256
+        result = runner.invoke(main, ["issue", "create", "-t", title])
+        assert result.exit_code != 0
+        assert "title must be 255 characters or fewer" in result.output
+        mock_client.post.assert_not_called()
+
     def test_web(self, runner, mock_client, mock_repo):
         with patch("gitcode_cli.commands.issue.open_in_browser") as mock_browser:
             result = runner.invoke(main, ["issue", "create", "-t", "T", "-w"])

--- a/tests/unit/test_cli_compat.py
+++ b/tests/unit/test_cli_compat.py
@@ -22,6 +22,10 @@ class TestGetBodyFromOptions:
         assert get_body_from_options(body="inline", body_file=None, editor=False) == "inline"
         edit_mock.assert_not_called()
 
+    def test_rejects_body_and_body_file_together(self):
+        with pytest.raises(click.UsageError, match="cannot use --body and --body-file together"):
+            get_body_from_options(body="inline", body_file="body.md", editor=False)
+
     def test_reads_body_from_file(self, tmp_path: Path):
         body_file = tmp_path / "body.md"
         body_file.write_text("file body", encoding="utf-8")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -6,6 +6,9 @@ import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import click
+import pytest
+
 from gitcode_cli.utils import (
     get_current_git_branch,
     get_default_git_branch,
@@ -79,6 +82,11 @@ class TestReadBodyFile:
         file_path = tmp_path / "body.md"
         file_path.write_text("Hello 世界", encoding="utf-8")
         assert read_body_file(str(file_path)) == "Hello 世界"
+
+    def test_raises_click_exception_for_missing_file(self, tmp_path: Path):
+        missing = tmp_path / "missing.md"
+        with pytest.raises(click.ClickException, match="Body file not found"):
+            read_body_file(str(missing))
 
 
 class TestOpenInBrowser:


### PR DESCRIPTION
Fixes issue create boundary handling for #31. This PR adds tests and minimal code changes to support stdin body input with -F -, reject -b and -F together, show a friendly error for missing body files, and reject titles longer than 255 characters before the API call. Closes #31.