### PR TITLE
fix: return non-zero exit code when pr review downgrades to comment (fixes #25)

### DIFF
--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -407,13 +407,13 @@ def pr_review(
             raise click.ClickException("Body is required when using --comment or --request-changes.")
         item = service.comment(owner, repo, number, body=body)
         if comment:
-            safe_echo("GitCode review API does not support comment reviews; posted a pull request comment instead.")
-        else:
-            safe_echo(
-                "GitCode review API does not support request-changes reviews; posted a pull request comment instead."
+            raise click.ClickException(
+                f"GitCode review API does not support comment reviews; posted a pull request comment instead. Comment ID: {item['id']}"
             )
-        safe_echo(f"Posted pull request comment {item['id']}")
-        return
+        else:
+            raise click.ClickException(
+                f"GitCode review API does not support request-changes reviews; posted a pull request comment instead. Comment ID: {item['id']}"
+            )
 
     item = service.review(owner, repo, number, body=body, force=force)
     safe_echo(f"Reviewed pull request #{number}")

--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -406,14 +406,14 @@ def pr_review(
         if not body:
             raise click.ClickException("Body is required when using --comment or --request-changes.")
         item = service.comment(owner, repo, number, body=body)
+        safe_echo(f"Posted pull request comment {item['id']}")
         if comment:
             raise click.ClickException(
-                f"GitCode review API does not support comment reviews; posted a pull request comment instead. Comment ID: {item['id']}"
+                "GitCode review API does not support comment reviews; the pull request comment was posted instead."
             )
-        else:
-            raise click.ClickException(
-                f"GitCode review API does not support request-changes reviews; posted a pull request comment instead. Comment ID: {item['id']}"
-            )
+        raise click.ClickException(
+            "GitCode review API does not support request-changes reviews; the pull request comment was posted instead."
+        )
 
     item = service.review(owner, repo, number, body=body, force=force)
     safe_echo(f"Reviewed pull request #{number}")

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -505,8 +505,8 @@ class TestPrReview:
         mock_client.post.return_value = {"id": 123}
         result = runner.invoke(main, ["pr", "review", "42", "--comment", "--body", "Needs more tests"])
         assert result.exit_code != 0
+        assert "Posted pull request comment 123" in result.output
         assert "does not support comment reviews" in result.output
-        assert "123" in result.output
         post_calls = [c for c in mock_client.post.call_args_list if "comments" in c.args[0]]
         assert len(post_calls) == 1
         assert post_calls[0].kwargs["json"]["body"] == "Needs more tests"
@@ -515,8 +515,8 @@ class TestPrReview:
         mock_client.post.return_value = {"id": 456}
         result = runner.invoke(main, ["pr", "review", "42", "--request-changes", "--body", "Please address feedback"])
         assert result.exit_code != 0
+        assert "Posted pull request comment 456" in result.output
         assert "does not support request-changes reviews" in result.output
-        assert "456" in result.output
         post_calls = [c for c in mock_client.post.call_args_list if "comments" in c.args[0]]
         assert len(post_calls) == 1
         assert post_calls[0].kwargs["json"]["body"] == "Please address feedback"
@@ -540,13 +540,13 @@ class TestPrReview:
         mock_client.post.return_value = {"id": 123}
         result = runner.invoke(main, ["pr", "review", "42", "--comment", "--body", "Needs more tests"])
         assert result.exit_code != 0
-        assert "does not support comment reviews" in result.output
+        assert "Posted pull request comment 123" in result.output
 
     def test_pr_review_request_changes_returns_nonzero_when_downgraded(self, runner, mock_client, mock_repo):
         mock_client.post.return_value = {"id": 456}
         result = runner.invoke(main, ["pr", "review", "42", "--request-changes", "--body", "Please address feedback"])
         assert result.exit_code != 0
-        assert "does not support request-changes reviews" in result.output
+        assert "Posted pull request comment 456" in result.output
 
 
 class TestPrReopen:

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -504,12 +504,9 @@ class TestPrReview:
     def test_pr_review_comment_downgrades_to_pr_comment_and_explains_it(self, runner, mock_client, mock_repo):
         mock_client.post.return_value = {"id": 123}
         result = runner.invoke(main, ["pr", "review", "42", "--comment", "--body", "Needs more tests"])
-        assert result.exit_code == 0
-        assert (
-            "GitCode review API does not support comment reviews; posted a pull request comment instead."
-            in result.output
-        )
-        assert "Posted pull request comment 123" in result.output
+        assert result.exit_code != 0
+        assert "does not support comment reviews" in result.output
+        assert "123" in result.output
         post_calls = [c for c in mock_client.post.call_args_list if "comments" in c.args[0]]
         assert len(post_calls) == 1
         assert post_calls[0].kwargs["json"]["body"] == "Needs more tests"
@@ -517,12 +514,9 @@ class TestPrReview:
     def test_pr_review_request_changes_downgrades_to_pr_comment_and_explains_it(self, runner, mock_client, mock_repo):
         mock_client.post.return_value = {"id": 456}
         result = runner.invoke(main, ["pr", "review", "42", "--request-changes", "--body", "Please address feedback"])
-        assert result.exit_code == 0
-        assert (
-            "GitCode review API does not support request-changes reviews; posted a pull request comment instead."
-            in result.output
-        )
-        assert "Posted pull request comment 456" in result.output
+        assert result.exit_code != 0
+        assert "does not support request-changes reviews" in result.output
+        assert "456" in result.output
         post_calls = [c for c in mock_client.post.call_args_list if "comments" in c.args[0]]
         assert len(post_calls) == 1
         assert post_calls[0].kwargs["json"]["body"] == "Please address feedback"
@@ -541,6 +535,18 @@ class TestPrReview:
         result = runner.invoke(main, ["pr", "review", "42", "--comment"])
         assert result.exit_code != 0
         assert "Body is required when using --comment or --request-changes." in result.output
+
+    def test_pr_review_comment_returns_nonzero_when_downgraded(self, runner, mock_client, mock_repo):
+        mock_client.post.return_value = {"id": 123}
+        result = runner.invoke(main, ["pr", "review", "42", "--comment", "--body", "Needs more tests"])
+        assert result.exit_code != 0
+        assert "does not support comment reviews" in result.output
+
+    def test_pr_review_request_changes_returns_nonzero_when_downgraded(self, runner, mock_client, mock_repo):
+        mock_client.post.return_value = {"id": 456}
+        result = runner.invoke(main, ["pr", "review", "42", "--request-changes", "--body", "Please address feedback"])
+        assert result.exit_code != 0
+        assert "does not support request-changes reviews" in result.output
 
 
 class TestPrReopen:


### PR DESCRIPTION
## Description

Return non-zero exit code when `gc pr review --comment/--request-changes` downgrades to a PR comment. Previously, the downgrade was silent with exit code 0, making it unclear that the review was not actually submitted.

## Related Issue

Fixes #25

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)

## Checklist

- [x] My code follows the project coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] My changes generate no new lint/type warnings
- [x] I have read the CONTRIBUTING.md guide