### PR TITLE
fix: reject mutually exclusive -b and -F in pr create (fixes #29)

### DIFF
--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -634,6 +634,30 @@ class TestPrCreateEdgeCases:
             assert result.exit_code == 0
             mock_browser.assert_called_once()
 
+    def test_pr_create_rejects_body_and_body_file_together(self, runner, mock_client, mock_repo, tmp_path):
+        body_file = tmp_path / "body.txt"
+        body_file.write_text("file body")
+        result = runner.invoke(
+            main,
+            [
+                "pr",
+                "create",
+                "-t",
+                "Test",
+                "-b",
+                "inline body",
+                "-F",
+                str(body_file),
+                "--base",
+                "master",
+                "--head",
+                "feature",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output.lower() or "only one" in result.output.lower()
+        mock_client.post.assert_not_called()
+
 
 class TestPrCloseEdgeCases:
     def test_close_delete_branch_no_ref(self, runner, mock_client, mock_repo):

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -655,7 +655,7 @@ class TestPrCreateEdgeCases:
             ],
         )
         assert result.exit_code != 0
-        assert "mutually exclusive" in result.output.lower() or "only one" in result.output.lower()
+        assert "cannot use --body and --body-file together" in result.output.lower()
         mock_client.post.assert_not_called()
 
 


### PR DESCRIPTION
## Description

Reject mutually exclusive -b/--body and -F/--body-file in pr create. Previously, get_body_from_options silently preferred body over body_file when both were provided.

## Related Issue

Fixes #29

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide