### PR TITLE
fix: reject mutually exclusive merge mode flags in pr merge (fixes #22)

### DIFF
--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -295,16 +295,18 @@ def pr_close(
 @pr_group.command("merge")
 @click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.argument("identifier", required=False)
-@click.option("-m", "--merge", "merge_mode", flag_value="merge")
-@click.option("-s", "--squash", "merge_mode", flag_value="squash")
-@click.option("-r", "--rebase", "merge_mode", flag_value="rebase")
+@click.option("-m", "--merge", is_flag=True, help="Merge the pull request.")
+@click.option("-s", "--squash", is_flag=True, help="Squash the pull request.")
+@click.option("-r", "--rebase", is_flag=True, help="Rebase the pull request.")
 @click.option("-d", "--delete-branch", is_flag=True, help="Delete the remote branch after merge.")
 @click.pass_context
 def pr_merge(
     ctx: click.Context,
     repo_name: str | None,
     identifier: str | None,
-    merge_mode: str | None,
+    merge: bool,
+    squash: bool,
+    rebase: bool,
     delete_branch: bool,
 ) -> None:
     app = ctx.obj["app"]
@@ -313,8 +315,12 @@ def pr_merge(
     resolved_identifier = resolve_pr_identifier_or_current_branch(identifier)
     owner, repo, number = resolve_pr_arg(resolved_identifier, owner, repo, service)
     number = int(number)
+    selected = [merge, squash, rebase]
+    if sum(selected) > 1:
+        raise click.UsageError("-m, -s, and -r are mutually exclusive. Specify only one merge method.")
+    merge_method = ["merge", "squash", "rebase"][selected.index(True)] if any(selected) else "merge"
     pr_item = service.get(owner, repo, number)
-    item = service.merge(owner, repo, number, merge_method=merge_mode or "merge")
+    item = service.merge(owner, repo, number, merge_method=merge_method)
     safe_echo(item["message"])
     if delete_branch:
         try:

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -427,6 +427,17 @@ class TestPrMerge:
         assert "Merged" in result.output
         assert mock_client.put.call_args.kwargs["json"]["merge_method"] == "rebase"
 
+    def test_pr_merge_rejects_mutually_exclusive_merge_flags(self, runner, mock_client, mock_repo):
+        result = runner.invoke(main, ["pr", "merge", "42", "-m", "-s"])
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output.lower() or "only one" in result.output.lower()
+        mock_client.put.assert_not_called()
+
+    def test_pr_merge_rejects_all_three_merge_flags(self, runner, mock_client, mock_repo):
+        result = runner.invoke(main, ["pr", "merge", "42", "-m", "-s", "-r"])
+        assert result.exit_code != 0
+        mock_client.put.assert_not_called()
+
 
 class TestPrComment:
     def test_pr_comment(self, runner, mock_client, mock_repo):


### PR DESCRIPTION
## Description

Reject mutually exclusive merge mode flags (-m, -s, -r) in `gc pr merge`. Previously, Click's flag_value silently took the last flag when multiple were specified.

## Related Issue

Fixes #22

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide