### PR TITLE
fix: add global GCError handler to eliminate Python tracebacks (fixes #23)

### DIFF
--- a/src/gitcode_cli/cli.py
+++ b/src/gitcode_cli/cli.py
@@ -33,11 +33,11 @@ def _get_version() -> str:
 
 
 class _GCMainGroup(click.Group):
-    def invoke(self, ctx: click.Context) -> None:
+    def invoke(self, ctx: click.Context):
         try:
             return super().invoke(ctx)
         except GCError as exc:
-            click.echo(f"error: {exc}", err=True)
+            safe_echo(f"error: {exc}", err=True)
             ctx.exit(1)
 
 

--- a/src/gitcode_cli/cli.py
+++ b/src/gitcode_cli/cli.py
@@ -32,7 +32,16 @@ def _get_version() -> str:
         return __version__
 
 
-@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+class _GCMainGroup(click.Group):
+    def invoke(self, ctx: click.Context) -> None:
+        try:
+            return super().invoke(ctx)
+        except GCError as exc:
+            click.echo(f"error: {exc}", err=True)
+            ctx.exit(1)
+
+
+@click.group(cls=_GCMainGroup, context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(version=_get_version(), prog_name="gitcode")
 @click.option("--repo", "repo_name", "-R", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.option("--token", hidden=True, help="Override authentication token.")
@@ -45,11 +54,6 @@ def main(ctx: click.Context, repo_name: str | None, token: str | None) -> None:
     except GCError:
         resolved_token = token
     ctx.obj["app"] = AppContext(token=resolved_token or "", repo=repo_name)
-
-
-@main.result_callback()
-def process_result(*_args: object, **_kwargs: object) -> None:
-    return None
 
 
 @main.command("version")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -6,6 +6,7 @@ import pytest
 from click.testing import CliRunner
 
 from gitcode_cli.cli import _configure_stdout_encoding, main
+from gitcode_cli.errors import APIError
 
 
 @pytest.fixture
@@ -154,3 +155,31 @@ class TestConfigureStdoutEncoding:
         monkeypatch.setattr("gitcode_cli.cli.sys.stderr", mock_stderr)
         monkeypatch.setattr("gitcode_cli.cli.sys.platform", "win32")
         _configure_stdout_encoding()
+
+
+class TestGlobalErrorHandler:
+    def test_api_error_produces_clean_message_without_traceback(self, runner):
+        """APIError should print a user-friendly message, not a Python traceback."""
+        with patch("gitcode_cli.cli.get_token", return_value="fake-token"):
+            with patch("gitcode_cli.context.AppContext.client") as mock_client_factory:
+                mock_client = MagicMock()
+                mock_client.get.side_effect = APIError("Not Found", status_code=404)
+                mock_client_factory.return_value = mock_client
+                result = runner.invoke(main, ["pr", "view", "999999"])
+        assert result.exit_code != 0
+        assert "Not Found" in result.output
+        assert "Traceback" not in result.output
+
+    def test_gc_error_produces_clean_message_without_traceback(self, runner):
+        """GCError subclass should print a clean message, not a traceback."""
+        from gitcode_cli.errors import AuthError
+
+        with patch("gitcode_cli.cli.get_token", return_value="fake-token"):
+            with patch("gitcode_cli.context.AppContext.client") as mock_client_factory:
+                mock_client = MagicMock()
+                mock_client.get.side_effect = AuthError("Invalid token")
+                mock_client_factory.return_value = mock_client
+                result = runner.invoke(main, ["pr", "list"])
+        assert result.exit_code != 0
+        assert "Invalid token" in result.output
+        assert "Traceback" not in result.output

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -88,7 +88,6 @@ class TestCli:
             import gitcode_cli.cli as cli_mod
 
             monkeypatch.setattr(cli_mod, "__name__", "__main__")
-            # Re-execute the module-level code by reloading
             importlib.reload(cli_mod)
             assert cli_mod.main is not None
 
@@ -159,19 +158,17 @@ class TestConfigureStdoutEncoding:
 
 class TestGlobalErrorHandler:
     def test_api_error_produces_clean_message_without_traceback(self, runner):
-        """APIError should print a user-friendly message, not a Python traceback."""
         with patch("gitcode_cli.cli.get_token", return_value="fake-token"):
             with patch("gitcode_cli.context.AppContext.client") as mock_client_factory:
                 mock_client = MagicMock()
                 mock_client.get.side_effect = APIError("Not Found", status_code=404)
                 mock_client_factory.return_value = mock_client
                 result = runner.invoke(main, ["pr", "view", "999999"])
-        assert result.exit_code != 0
-        assert "Not Found" in result.output
+        assert result.exit_code == 1
+        assert "error: Not Found" in result.output
         assert "Traceback" not in result.output
 
     def test_gc_error_produces_clean_message_without_traceback(self, runner):
-        """GCError subclass should print a clean message, not a traceback."""
         from gitcode_cli.errors import AuthError
 
         with patch("gitcode_cli.cli.get_token", return_value="fake-token"):
@@ -180,6 +177,6 @@ class TestGlobalErrorHandler:
                 mock_client.get.side_effect = AuthError("Invalid token")
                 mock_client_factory.return_value = mock_client
                 result = runner.invoke(main, ["pr", "list"])
-        assert result.exit_code != 0
-        assert "Invalid token" in result.output
+        assert result.exit_code == 1
+        assert "error: Invalid token" in result.output
         assert "Traceback" not in result.output


### PR DESCRIPTION
## Description

Add a global GCError exception handler to the CLI entry point. When any GCError (APIError, AuthError, etc.) is raised, it now displays a clean error message instead of a Python traceback.

## Related Issue

Fixes #23

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide