### PR TITLE
fix: template takes priority over json in output_result (fixes #26)

### DIFF
--- a/src/gitcode_cli/formatters.py
+++ b/src/gitcode_cli/formatters.py
@@ -151,15 +151,21 @@ def output_result(data, json_fields: str | None, jq_query: str | None, template:
         data = apply_jq(data, jq_query)
         safe_echo(dump_json(data))
         return
-    if json_fields:
-        fields = [f.strip() for f in json_fields.split(",")]
-        safe_echo(dump_json(data, fields=fields))
-        return
     if template:
+        if json_fields:
+            fields = [f.strip() for f in json_fields.split(",")]
+            if isinstance(data, list):
+                data = [_filter_fields(item, fields) for item in data]
+            else:
+                data = _filter_fields(data, fields)
         if isinstance(data, list):
             for item in data:
                 safe_echo(render_template(item, template))
         else:
             safe_echo(render_template(data, template))
+        return
+    if json_fields:
+        fields = [f.strip() for f in json_fields.split(",")]
+        safe_echo(dump_json(data, fields=fields))
         return
     default_formatter(data)

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -132,6 +132,20 @@ class TestPrList:
         assert '"number": 1' in result.output
         assert '"title": "First PR"' in result.output
 
+    def test_pr_list_template_with_json_uses_template(self, runner, mock_client, mock_repo):
+        mock_client.get.return_value = [
+            {"number": 1, "title": "First PR"},
+            {"number": 2, "title": "Second PR"},
+        ]
+        result = runner.invoke(
+            main,
+            ["pr", "list", "--json", "number,title", "-t", "{{.number}} {{.title}}"],
+        )
+        assert result.exit_code == 0
+        assert "1 First PR" in result.output
+        assert "2 Second PR" in result.output
+        assert '"number"' not in result.output
+
     def test_pr_list_alias_ls(self, runner, mock_client, mock_repo):
         mock_client.get.return_value = [
             {"number": 1, "state": "open", "title": "First PR"},


### PR DESCRIPTION
## Description

Fix output_result priority so that --template takes precedence over --json. When both --json and --template are specified, the JSON fields are used to filter data first, then the template renders the filtered data.

## Related Issue

Fixes #26

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide