### PR TITLE
fix: fetch PR detail before close to capture branch ref for -d (fixes #28)

### DIFF
--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -276,12 +276,13 @@ def pr_close(
     resolved_identifier = resolve_pr_identifier_or_current_branch(identifier)
     owner, repo, number = resolve_pr_arg(resolved_identifier, owner, repo, service)
     number = int(number)
+    pr_item = service.get(owner, repo, number) if delete_branch else None
     if comment:
         service.comment(owner, repo, number, body=comment)
     item = service.update(owner, repo, number, state="closed")
     if delete_branch:
         try:
-            branch = item.get("head", {}).get("ref")
+            branch = (pr_item or item).get("head", {}).get("ref")
             if branch:
                 subprocess.run(["git", "push", "origin", "--delete", branch], check=True)
                 safe_echo(f"Deleted remote branch {branch}")

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -370,6 +370,7 @@ class TestPrClose:
 
     def test_pr_close_delete_branch(self, runner, mock_client, mock_repo):
         with patch("gitcode_cli.commands.pr.subprocess.run") as mock_run:
+            mock_client.get.return_value = {"number": 42, "head": {"ref": "feature"}}
             mock_client.patch.return_value = {"number": 42, "head": {"ref": "feature"}}
             result = runner.invoke(main, ["pr", "close", "42", "-d"])
             assert result.exit_code == 0
@@ -626,6 +627,7 @@ class TestPrCreateEdgeCases:
 
 class TestPrCloseEdgeCases:
     def test_close_delete_branch_no_ref(self, runner, mock_client, mock_repo):
+        mock_client.get.return_value = {"number": 42, "head": {}}
         mock_client.patch.return_value = {"number": 42, "head": {}}
         with patch("gitcode_cli.commands.pr.subprocess.run") as mock_run:
             result = runner.invoke(main, ["pr", "close", "42", "-d"])
@@ -634,12 +636,26 @@ class TestPrCloseEdgeCases:
             mock_run.assert_not_called()
 
     def test_close_delete_branch_git_fails(self, runner, mock_client, mock_repo):
+        mock_client.get.return_value = {"number": 42, "head": {"ref": "feature"}}
         mock_client.patch.return_value = {"number": 42, "head": {"ref": "feature"}}
         with patch("gitcode_cli.commands.pr.subprocess.run") as mock_run:
             mock_run.side_effect = Exception("git failed")
             result = runner.invoke(main, ["pr", "close", "42", "-d"])
             assert result.exit_code == 0
             assert "Warning: could not delete remote branch" in result.output
+
+    def test_close_delete_branch_fetches_pr_before_close(self, runner, mock_client, mock_repo):
+        """When close response lacks head.ref, we should have fetched it beforehand."""
+        mock_client.get.return_value = {"number": 42, "head": {"ref": "feature"}}
+        mock_client.patch.return_value = {"number": 42, "head": {}}
+        with patch("gitcode_cli.commands.pr.subprocess.run") as mock_run:
+            result = runner.invoke(main, ["pr", "close", "42", "-d"])
+            assert result.exit_code == 0
+            assert "Deleted remote branch feature" in result.output
+            mock_run.assert_called_once_with(
+                ["git", "push", "origin", "--delete", "feature"],
+                check=True,
+            )
 
 
 class TestPrReviewEdgeCases:


### PR DESCRIPTION
## Description

Fetch PR detail before closing to capture the branch reference for -d flag. Previously, when the API close response didn't include head.ref, the remote branch could not be deleted.

## Related Issue

Fixes #28

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide