### PR TITLE
fix: add completion command and issue develop stub

### DIFF
--- a/src/gitcode_cli/cli.py
+++ b/src/gitcode_cli/cli.py
@@ -5,6 +5,7 @@ import importlib.metadata
 import sys
 
 import click
+from click.shell_completion import get_completion_class
 
 from . import __version__
 from .commands.auth import auth_group
@@ -64,8 +65,6 @@ def version_command() -> None:
 @main.command("completion")
 @click.argument("shell", type=click.Choice(["bash", "zsh", "fish"]))
 def completion_command(shell: str) -> None:
-    from click.shell_completion import get_completion_class
-
     comp_class = get_completion_class(shell)
     if comp_class is None:
         raise click.ClickException(f"Shell completion not supported for: {shell}")

--- a/src/gitcode_cli/cli.py
+++ b/src/gitcode_cli/cli.py
@@ -61,6 +61,18 @@ def version_command() -> None:
     safe_echo(f"gitcode version {_get_version()}")
 
 
+@main.command("completion")
+@click.argument("shell", type=click.Choice(["bash", "zsh", "fish"]))
+def completion_command(shell: str) -> None:
+    from click.shell_completion import get_completion_class
+
+    comp_class = get_completion_class(shell)
+    if comp_class is None:
+        raise click.ClickException(f"Shell completion not supported for: {shell}")
+    comp = comp_class(main, {}, "gc", "_GC_COMPLETE")
+    safe_echo(comp.source())
+
+
 main.add_command(auth_group)
 main.add_command(issue_group)
 main.add_command(pr_group)

--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -364,5 +364,31 @@ def issue_status(ctx: click.Context, repo_name: str | None) -> None:
         safe_echo(f"  #{safe_number(item, '?')}\t{item['state']}\t{item['title']}")
 
 
+@issue_group.command("develop")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.argument("identifier")
+@click.option("-b", "--base", help="Base branch for the develop branch.")
+@click.option("-n", "--name", help="Name for the local branch.")
+@click.pass_context
+def issue_develop(
+    ctx: click.Context,
+    repo_name: str | None,
+    identifier: str,
+    base: str | None,
+    name: str | None,
+) -> None:
+    app = ctx.obj["app"]
+    url_owner, url_repo, number = resolve_issue_arg(identifier)
+    if url_owner:
+        assert url_repo is not None
+        owner, repo = url_owner, url_repo
+    else:
+        owner, repo = resolve_repo(repo_name or app.repo)
+    _ = base, name
+    safe_echo("Note: 'issue develop' is not fully supported on GitCode.")
+    safe_echo(f"Opening issue #{number} in the browser instead.")
+    open_in_browser(f"https://gitcode.com/{owner}/{repo}/issues/{number}")
+
+
 issue_group.add_command(issue_list, name="ls")
 issue_group.add_command(issue_create, name="new")

--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -377,6 +377,9 @@ def issue_develop(
     base: str | None,
     name: str | None,
 ) -> None:
+    if base is not None or name is not None:
+        raise click.UsageError("--base and --name are not supported by 'gc issue develop'")
+
     app = ctx.obj["app"]
     url_owner, url_repo, number = resolve_issue_arg(identifier)
     if url_owner:
@@ -384,8 +387,7 @@ def issue_develop(
         owner, repo = url_owner, url_repo
     else:
         owner, repo = resolve_repo(repo_name or app.repo)
-    _ = base, name
-    safe_echo("Note: 'issue develop' is not fully supported on GitCode.")
+    safe_echo("Note: 'issue develop' does not create a local branch on GitCode.")
     safe_echo(f"Opening issue #{number} in the browser instead.")
     open_in_browser(f"https://gitcode.com/{owner}/{repo}/issues/{number}")
 

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -442,6 +442,20 @@ class TestIssueDelete:
         assert result.exit_code == 0
 
 
+class TestIssueDevelop:
+    def test_develop_opens_browser(self, runner, mock_client, mock_repo):
+        with patch("gitcode_cli.commands.issue.open_in_browser") as mock_browser:
+            result = runner.invoke(main, ["issue", "develop", "42"])
+        assert result.exit_code == 0
+        assert "not fully supported" in result.output
+        mock_browser.assert_called_once_with("https://gitcode.com/owner/repo/issues/42")
+
+    def test_develop_help(self, runner):
+        result = runner.invoke(main, ["issue", "develop", "--help"])
+        assert result.exit_code == 0
+        assert "Create a local branch" in result.output
+
+
 class TestIssueStatus:
     def test_default(self, runner, mock_client, mock_repo):
         mock_client.get.return_value = [{"number": "1", "state": "open", "title": "T"}]

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -447,13 +447,30 @@ class TestIssueDevelop:
         with patch("gitcode_cli.commands.issue.open_in_browser") as mock_browser:
             result = runner.invoke(main, ["issue", "develop", "42"])
         assert result.exit_code == 0
-        assert "not fully supported" in result.output
+        assert "does not create a local branch" in result.output
         mock_browser.assert_called_once_with("https://gitcode.com/owner/repo/issues/42")
 
     def test_develop_help(self, runner):
         result = runner.invoke(main, ["issue", "develop", "--help"])
         assert result.exit_code == 0
-        assert "Create a local branch" in result.output
+        assert "Base branch for the develop branch." in result.output
+        assert "Name for the local branch." in result.output
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["--base", "main"],
+            ["--name", "feature-42"],
+            ["--base", "main", "--name", "feature-42"],
+        ],
+    )
+    def test_rejects_unimplemented_branch_options(self, runner, mock_client, mock_repo, args):
+        with patch("gitcode_cli.commands.issue.open_in_browser") as mock_browser:
+            result = runner.invoke(main, ["issue", "develop", "42", *args])
+
+        assert result.exit_code != 0
+        assert "--base and --name are not supported" in result.output
+        mock_browser.assert_not_called()
 
 
 class TestIssueStatus:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -156,6 +156,22 @@ class TestConfigureStdoutEncoding:
         _configure_stdout_encoding()
 
 
+class TestCompletion:
+    def test_completion_zsh(self, runner):
+        result = runner.invoke(main, ["completion", "zsh"])
+        assert result.exit_code == 0
+        assert len(result.output) > 0
+
+    def test_completion_bash(self, runner):
+        result = runner.invoke(main, ["completion", "bash"])
+        assert result.exit_code == 0
+        assert len(result.output) > 0
+
+    def test_completion_invalid_shell(self, runner):
+        result = runner.invoke(main, ["completion", "invalid_shell"])
+        assert result.exit_code != 0
+
+
 class TestGlobalErrorHandler:
     def test_api_error_produces_clean_message_without_traceback(self, runner):
         with patch("gitcode_cli.cli.get_token", return_value="fake-token"):
@@ -180,3 +196,4 @@ class TestGlobalErrorHandler:
         assert result.exit_code == 1
         assert "error: Invalid token" in result.output
         assert "Traceback" not in result.output
+

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -196,4 +196,3 @@ class TestGlobalErrorHandler:
         assert result.exit_code == 1
         assert "error: Invalid token" in result.output
         assert "Traceback" not in result.output
-


### PR DESCRIPTION
## Description

Add gh-compatible command surface for issue #36 by introducing a top-level `gc completion` command and an `gc issue develop` compatibility stub that opens the related issue in the browser.

## Related Issue

Closes #36

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [ ] Test coverage remains >= 90%

- Added focused tests for `gc completion` in `tests/unit/test_cli.py`
- Added focused tests for `gc issue develop` in `tests/unit/commands/test_issue.py`
- Ran `python -m pytest tests/unit/test_cli.py`
- Ran `python -m pytest tests/unit/commands/test_issue.py`

## Checklist

- [x] My code follows the projects coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [ ] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide