### PR TITLE
fix: handle rebase merge errors gracefully (fixes #27)

### DIFF
--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -453,6 +453,16 @@ class TestPrMerge:
         assert result.exit_code != 0
         mock_client.put.assert_not_called()
 
+    def test_pr_merge_rebase_error_shows_clean_message(self, runner, mock_client, mock_repo):
+        from gitcode_cli.errors import APIError
+
+        mock_client.get.return_value = {"number": 42, "state": "open"}
+        mock_client.put.side_effect = APIError("this patch has already been applied", status_code=405)
+        result = runner.invoke(main, ["pr", "merge", "42", "-r"])
+        assert result.exit_code != 0
+        assert "this patch has already been applied" in result.output
+        assert "Traceback" not in result.output
+
 
 class TestPrComment:
     def test_pr_comment(self, runner, mock_client, mock_repo):


### PR DESCRIPTION
## Description

Add global GCError exception handler and merge-specific error test. When rebase merge fails (e.g., patch already applied), the error is now displayed as a clean message instead of a Python traceback.

## Related Issue

Fixes #27

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)

## Checklist

- [x] My code follows the project coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide