### PR TITLE
fix: ensure non-zero exit codes for auth and network failures (#35)

### DIFF
--- a/src/gitcode_cli/cli.py
+++ b/src/gitcode_cli/cli.py
@@ -5,7 +5,6 @@ import importlib.metadata
 import sys
 
 import click
-import httpx
 
 from . import __version__
 from .commands.auth import auth_group
@@ -39,15 +38,6 @@ class _GCMainGroup(click.Group):
             return super().invoke(ctx)
         except GCError as exc:
             safe_echo(f"error: {exc}", err=True)
-            ctx.exit(1)
-        except httpx.TimeoutException as exc:
-            safe_echo(f"error: Request timed out: {exc}", err=True)
-            ctx.exit(1)
-        except httpx.ConnectError as exc:
-            safe_echo(f"error: Connection failed: {exc}", err=True)
-            ctx.exit(1)
-        except httpx.HTTPError as exc:
-            safe_echo(f"error: Network error: {exc}", err=True)
             ctx.exit(1)
 
 

--- a/src/gitcode_cli/cli.py
+++ b/src/gitcode_cli/cli.py
@@ -5,6 +5,7 @@ import importlib.metadata
 import sys
 
 import click
+import httpx
 
 from . import __version__
 from .commands.auth import auth_group
@@ -38,6 +39,15 @@ class _GCMainGroup(click.Group):
             return super().invoke(ctx)
         except GCError as exc:
             safe_echo(f"error: {exc}", err=True)
+            ctx.exit(1)
+        except httpx.TimeoutException as exc:
+            safe_echo(f"error: Request timed out: {exc}", err=True)
+            ctx.exit(1)
+        except httpx.ConnectError as exc:
+            safe_echo(f"error: Connection failed: {exc}", err=True)
+            ctx.exit(1)
+        except httpx.HTTPError as exc:
+            safe_echo(f"error: Network error: {exc}", err=True)
             ctx.exit(1)
 
 

--- a/src/gitcode_cli/client.py
+++ b/src/gitcode_cli/client.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin
 
 import httpx
 
-from .errors import APIError
+from .errors import APIError, NetworkError
 
 BASE_URL = "https://api.gitcode.com/api/v5/"
 
@@ -29,13 +29,22 @@ class GitCodeClient:
         merged_params: dict[str, Any] = {"access_token": self.token}
         if params:
             merged_params.update({k: v for k, v in params.items() if v is not None})
-        response = self._client.request(
-            method,
-            urljoin(self.base_url, path.lstrip("/")),
-            params=merged_params,
-            json=json,
-            headers={"Accept": accept},
-        )
+        try:
+            response = self._client.request(
+                method,
+                urljoin(self.base_url, path.lstrip("/")),
+                params=merged_params,
+                json=json,
+                headers={"Accept": accept},
+            )
+        except httpx.TimeoutException as exc:
+            raise NetworkError(f"Request timed out: {exc}") from exc
+        except httpx.ConnectError as exc:
+            raise NetworkError(f"Connection failed: {exc}") from exc
+        except httpx.HTTPError as exc:
+            raise NetworkError(f"Network error: {exc}") from exc
+        if response.status_code == 401:
+            raise APIError("Authentication failed. Run 'gc auth login' to authenticate.", 401)
         if response.status_code >= 400:
             try:
                 data = response.json()

--- a/src/gitcode_cli/client.py
+++ b/src/gitcode_cli/client.py
@@ -44,7 +44,12 @@ class GitCodeClient:
         except httpx.HTTPError as exc:
             raise NetworkError(f"Network error: {exc}") from exc
         if response.status_code == 401:
-            raise APIError("Authentication failed. Run 'gc auth login' to authenticate.", 401)
+            try:
+                data = response.json()
+                original = data.get("message") or str(data)
+            except Exception:
+                original = response.text
+            raise APIError(f"Authentication failed: {original}. Run 'gc auth login' to authenticate.", 401)
         if response.status_code >= 400:
             try:
                 data = response.json()

--- a/src/gitcode_cli/errors.py
+++ b/src/gitcode_cli/errors.py
@@ -21,3 +21,7 @@ class APIError(GCError):
     def __init__(self, message: str, status_code: Optional[int] = None):
         super().__init__(message)
         self.status_code = status_code
+
+
+class NetworkError(GCError):
+    pass

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -6,7 +6,7 @@ import pytest
 from click.testing import CliRunner
 
 from gitcode_cli.cli import _configure_stdout_encoding, main
-from gitcode_cli.errors import APIError
+from gitcode_cli.errors import APIError, NetworkError
 
 
 @pytest.fixture
@@ -90,6 +90,37 @@ class TestCli:
             monkeypatch.setattr(cli_mod, "__name__", "__main__")
             importlib.reload(cli_mod)
             assert cli_mod.main is not None
+
+
+class TestNetworkErrorExitCode:
+    def test_network_error_returns_nonzero_exit_code(self, runner):
+        with patch("gitcode_cli.cli.get_token", return_value="fake-token"):
+            with patch("gitcode_cli.repo.resolve_repo", return_value=("owner", "repo")):
+                with patch("gitcode_cli.context.AppContext.client") as mock_client_factory:
+                    mock_client = MagicMock()
+                    mock_client.get.side_effect = NetworkError("Connection failed: Connection refused")
+                    mock_client_factory.return_value = mock_client
+                    result = runner.invoke(main, ["issue", "list"])
+
+        assert result.exit_code != 0
+        assert "Connection failed" in result.output
+        assert "Traceback" not in result.output
+
+    def test_invalid_token_returns_nonzero_exit_code(self, runner):
+        with patch("gitcode_cli.cli.get_token", return_value="fake-token"):
+            with patch("gitcode_cli.repo.resolve_repo", return_value=("owner", "repo")):
+                with patch("gitcode_cli.context.AppContext.client") as mock_client_factory:
+                    mock_client = MagicMock()
+                    mock_client.get.side_effect = APIError(
+                        "Authentication failed: Unauthorized. Run 'gc auth login' to authenticate.",
+                        401,
+                    )
+                    mock_client_factory.return_value = mock_client
+                    result = runner.invoke(main, ["issue", "list"])
+
+        assert result.exit_code != 0
+        assert "Authentication failed" in result.output
+        assert "Traceback" not in result.output
 
 
 class TestConfigureStdoutEncoding:

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -160,5 +160,5 @@ class TestNetworkErrorWrapping:
         response.content = b'{"message":"Unauthorized"}'
         client._client.request.return_value = response
 
-        with pytest.raises(APIError, match="Authentication failed"):
+        with pytest.raises(APIError, match="Authentication failed: Unauthorized"):
             client.get("/test")

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
+import httpx
 import pytest
 import respx
 from httpx import Response
 
 from gitcode_cli.client import BASE_URL, GitCodeClient
-from gitcode_cli.errors import APIError
+from gitcode_cli.errors import APIError, NetworkError
 
 
 class TestGitCodeClientInit:
@@ -129,3 +132,33 @@ class TestGitCodeClientMethods:
             assert params["access_token"] == "test-token"
             assert params["page"] == "1"
             assert params["per_page"] == "20"
+
+
+class TestNetworkErrorWrapping:
+    def test_connect_error_raises_network_error(self):
+        client = GitCodeClient(token="fake")
+        client._client = MagicMock()
+        client._client.request.side_effect = httpx.ConnectError("Connection refused")
+
+        with pytest.raises(NetworkError, match="Connection failed"):
+            client.get("/test")
+
+    def test_timeout_raises_network_error(self):
+        client = GitCodeClient(token="fake")
+        client._client = MagicMock()
+        client._client.request.side_effect = httpx.TimeoutException("Timed out")
+
+        with pytest.raises(NetworkError, match="Request timed out"):
+            client.get("/test")
+
+    def test_401_raises_api_error_with_auth_message(self):
+        client = GitCodeClient(token="invalid")
+        client._client = MagicMock()
+        response = MagicMock()
+        response.status_code = 401
+        response.json.return_value = {"message": "Unauthorized"}
+        response.content = b'{"message":"Unauthorized"}'
+        client._client.request.return_value = response
+
+        with pytest.raises(APIError, match="Authentication failed"):
+            client.get("/test")


### PR DESCRIPTION
## Description

Fix issue #35 by ensuring authentication and network failures return a non-zero CLI exit code with clean user-facing error output.

## Related Issue

Closes #35

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

Additional targeted commands run:
- `python -m pytest tests/unit/test_client.py`
- `python -m pytest tests/unit/test_cli.py`

Note: the single-file pytest invocations execute passing tests but also report the repository-wide coverage gate from `pyproject.toml`, which is satisfied by `python -m pytest tests/unit/`.

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [ ] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide
