### PR TITLE
fix pr review comment semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ gc pr view -w
 | `--web` (create/view in browser) | ✅ | ✅ |
 | `--remove-*` flags for edit commands | ✅ | ✅ |
 | `pr ready --undo` (convert to draft) | ✅ | ✅ |
-| `pr review --comment` / `--request-changes` | ✅ | ✅ (fallback) |
+| `pr review --request-changes` | ✅ | ✅ (fallback) |
 | `--json fields` | ✅ | ✅ |
 | `-q jq` filtering | ✅ | ✅ |
 | `-t template` formatting | ✅ | ✅ |
@@ -208,7 +208,7 @@ gc pr view -w
 ### Known Limitations (GitCode API differences)
 
 - **PR comment model**: GitCode uses `path + position`, not GitHub's `line/side/commit`
-- **PR review**: GitCode review API differs from GitHub; `--comment` and `--request-changes` fall back to PR comments
+- **PR review**: GitCode review API differs from GitHub; `--request-changes` falls back to PR comments
 - **Issue create/update API**: GitCode puts `repo` in request body, not URL path
 
 ## Development

--- a/src/gitcode_cli/adapters/capabilities.py
+++ b/src/gitcode_cli/adapters/capabilities.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 import click
 
 CAPABILITY_MESSAGES = {
-    "PR_REVIEW_COMMENT": (
-        "GitCode review API does not support comment reviews; the pull request comment was posted instead."
-    ),
     "PR_REVIEW_REQUEST_CHANGES": (
         "GitCode review API does not support request-changes reviews; the pull request comment was posted instead."
     ),

--- a/src/gitcode_cli/adapters/pulls.py
+++ b/src/gitcode_cli/adapters/pulls.py
@@ -87,17 +87,10 @@ class PullRequestAdapter:
         *,
         approve: bool,  # noqa: ARG002
         body: str | None,
-        comment: bool,
+        comment: bool,  # noqa: ARG002
         request_changes: bool,
         force: bool,
     ) -> AdapterActionResult:
-        if comment:
-            item = self.service.comment(owner, repo, number, body=body or "")
-            return AdapterActionResult(
-                item=item,
-                message=capability_message("PR_REVIEW_COMMENT"),
-                degraded=True,
-            )
         if request_changes:
             item = self.service.comment(owner, repo, number, body=body or "")
             return AdapterActionResult(

--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -380,7 +380,7 @@ def pr_comment(
 @click.argument("identifier", required=False)
 @click.option("-a", "--approve", is_flag=True, help="Approve the pull request. GitCode maps this to its review API.")
 @click.option("--body")
-@click.option("--comment", is_flag=True, help="Leave a review comment. Downgrades to a PR comment on GitCode.")
+@click.option("--comment", is_flag=True, help="Leave a review comment.")
 @click.option("--request-changes", is_flag=True, help="Request changes. Downgrades to a PR comment on GitCode.")
 @click.option("--force", is_flag=True, help="Force review handling when supported by GitCode.")
 @click.pass_context

--- a/tests/unit/adapters/test_pulls_adapter.py
+++ b/tests/unit/adapters/test_pulls_adapter.py
@@ -96,8 +96,8 @@ class TestPullRequestAdapter:
         assert result.degraded is False
         assert result.item == {"state": "APPROVED"}
 
-    def test_review_pr_comment_degrades_to_regular_comment(self, adapter, service):
-        service.comment.return_value = {"id": 7}
+    def test_review_pr_comment_uses_review_api(self, adapter, service):
+        service.review.return_value = {"id": 7}
 
         result = adapter.review_pr(
             "owner",
@@ -110,10 +110,28 @@ class TestPullRequestAdapter:
             force=False,
         )
 
-        service.comment.assert_called_once_with("owner", "repo", 42, body="needs tests")
-        assert result.degraded is True
+        service.review.assert_called_once_with("owner", "repo", 42, body="needs tests", force=False)
+        assert result.degraded is False
         assert result.item == {"id": 7}
-        assert "comment reviews" in result.message
+
+    def test_review_pr_request_changes_degrades_to_comment(self, adapter, service):
+        service.comment.return_value = {"id": 9}
+
+        result = adapter.review_pr(
+            "owner",
+            "repo",
+            42,
+            approve=False,
+            body="please fix",
+            comment=False,
+            request_changes=True,
+            force=False,
+        )
+
+        service.comment.assert_called_once_with("owner", "repo", 42, body="please fix")
+        service.review.assert_not_called()
+        assert result.degraded is True
+        assert "request-changes" in result.message
 
     def test_status_returns_approximation_message(self, adapter, service):
         service.list.return_value = [{"number": 1, "state": "open", "title": "Test"}]

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -501,15 +501,14 @@ class TestPrReview:
         assert "Reviewed pull request #42" in result.output
         mock_resolver.assert_called_once_with(None)
 
-    def test_pr_review_comment_downgrades_to_pr_comment_and_explains_it(self, runner, mock_client, mock_repo):
+    def test_pr_review_comment_uses_review_api(self, runner, mock_client, mock_repo):
         mock_client.post.return_value = {"id": 123}
         result = runner.invoke(main, ["pr", "review", "42", "--comment", "--body", "Needs more tests"])
-        assert result.exit_code != 0
-        assert "Posted pull request comment 123" in result.output
-        assert "does not support comment reviews" in result.output
-        post_calls = [c for c in mock_client.post.call_args_list if "comments" in c.args[0]]
-        assert len(post_calls) == 1
-        assert post_calls[0].kwargs["json"]["body"] == "Needs more tests"
+        assert result.exit_code == 0
+        assert "Reviewed pull request #42" in result.output
+        review_calls = [c for c in mock_client.post.call_args_list if "review" in c.args[0]]
+        assert len(review_calls) == 1
+        assert review_calls[0].kwargs["json"]["body"] == "Needs more tests"
 
     def test_pr_review_request_changes_downgrades_to_pr_comment_and_explains_it(self, runner, mock_client, mock_repo):
         mock_client.post.return_value = {"id": 456}
@@ -536,11 +535,11 @@ class TestPrReview:
         assert result.exit_code != 0
         assert "Body is required when using --comment or --request-changes." in result.output
 
-    def test_pr_review_comment_returns_nonzero_when_downgraded(self, runner, mock_client, mock_repo):
+    def test_pr_review_comment_returns_zero_on_success(self, runner, mock_client, mock_repo):
         mock_client.post.return_value = {"id": 123}
         result = runner.invoke(main, ["pr", "review", "42", "--comment", "--body", "Needs more tests"])
-        assert result.exit_code != 0
-        assert "Posted pull request comment 123" in result.output
+        assert result.exit_code == 0
+        assert "Reviewed pull request #42" in result.output
 
     def test_pr_review_request_changes_returns_nonzero_when_downgraded(self, runner, mock_client, mock_repo):
         mock_client.post.return_value = {"id": 456}


### PR DESCRIPTION
## Description

This PR fixes `gc pr review --comment` so it uses the GitCode review API and exits successfully instead of degrading to a normal pull request comment.

## Related Issue

Fixes #53

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

Test details:
- pre-commit hooks passed during commit (`ruff`, `ruff-format`, `basedpyright`, `pytest`)
- full suite passed: `/Users/test1/liuyekang/miniconda3/envs/gitcode-cli/bin/python -m pytest tests/`
- resulting coverage: `92.33%`

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [ ] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide