### PR TITLE
fix: handle existing local branch in pr checkout (fixes #54)

### DIFF
--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -546,12 +546,38 @@ def pr_checkout(ctx: click.Context, repo_name: str | None, identifier: str | Non
     if not head_ref:
         raise click.ClickException("Unable to determine PR branch.")
     local_branch = branch or head_ref
+    remote_tracking = f"origin/{head_ref}"
     try:
         subprocess.run(["git", "fetch", "origin", head_ref], check=True)
-        subprocess.run(["git", "checkout", "-b", local_branch, f"origin/{head_ref}"], check=True)
-        safe_echo(f"Checked out branch {local_branch}")
     except subprocess.CalledProcessError as exc:
-        raise click.ClickException(f"Git checkout failed: {exc}") from exc
+        raise click.ClickException(f"Git fetch failed: {exc}") from exc
+
+    # Check if a local branch with this name already exists
+    existing = subprocess.run(
+        ["git", "rev-parse", "--verify", local_branch],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if existing.returncode == 0:
+        # Branch exists — check if it tracks the expected remote ref
+        tracking = subprocess.run(
+            ["git", "for-each-ref", "--format=%(upstream:short)", f"refs/heads/{local_branch}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if tracking.stdout.strip() == remote_tracking:
+            subprocess.run(["git", "checkout", local_branch], check=True)
+            safe_echo(f"Checked out existing branch {local_branch} (tracking {remote_tracking})")
+        else:
+            raise click.ClickException(
+                f"A branch named '{local_branch}' already exists and does not track {remote_tracking}. "
+                f"Use --branch to specify a different name, or rename/delete the existing branch."
+            )
+    else:
+        subprocess.run(["git", "checkout", "-b", local_branch, remote_tracking], check=True)
+        safe_echo(f"Checked out branch {local_branch}")
 
 
 @pr_group.command("ready")

--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -554,7 +554,7 @@ def pr_checkout(ctx: click.Context, repo_name: str | None, identifier: str | Non
 
     # Check if a local branch with this name already exists
     existing = subprocess.run(
-        ["git", "rev-parse", "--verify", local_branch],
+        ["git", "rev-parse", "--verify", f"refs/heads/{local_branch}"],
         capture_output=True,
         text=True,
         check=False,
@@ -568,7 +568,10 @@ def pr_checkout(ctx: click.Context, repo_name: str | None, identifier: str | Non
             check=False,
         )
         if tracking.stdout.strip() == remote_tracking:
-            subprocess.run(["git", "checkout", local_branch], check=True)
+            try:
+                subprocess.run(["git", "checkout", local_branch], check=True)
+            except subprocess.CalledProcessError as exc:
+                raise click.ClickException(f"Git checkout failed: {exc}") from exc
             safe_echo(f"Checked out existing branch {local_branch} (tracking {remote_tracking})")
         else:
             raise click.ClickException(
@@ -576,7 +579,10 @@ def pr_checkout(ctx: click.Context, repo_name: str | None, identifier: str | Non
                 f"Use --branch to specify a different name, or rename/delete the existing branch."
             )
     else:
-        subprocess.run(["git", "checkout", "-b", local_branch, remote_tracking], check=True)
+        try:
+            subprocess.run(["git", "checkout", "-b", local_branch, remote_tracking], check=True)
+        except subprocess.CalledProcessError as exc:
+            raise click.ClickException(f"Git checkout failed: {exc}") from exc
         safe_echo(f"Checked out branch {local_branch}")
 
 

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -618,7 +618,8 @@ class TestPrCheckout:
             result = runner.invoke(main, ["pr", "checkout", "42"])
             assert result.exit_code == 0
             assert "Checked out branch feature-branch" in result.output
-            assert mock_run.call_count == 2
+            # fetch, rev-parse (branch doesn't exist), checkout -b
+            assert mock_run.call_count == 3
             mock_run.assert_any_call(
                 ["git", "fetch", "origin", "feature-branch"],
                 check=True,
@@ -627,6 +628,46 @@ class TestPrCheckout:
                 ["git", "checkout", "-b", "feature-branch", "origin/feature-branch"],
                 check=True,
             )
+
+    def test_pr_checkout_existing_branch_with_correct_tracking(self, runner, mock_client, mock_repo):
+        with patch("gitcode_cli.commands.pr.subprocess.run") as mock_run:
+            mock_client.get.return_value = {"number": 42, "head": {"ref": "feature-branch"}}
+            # rev-parse succeeds (branch exists), for-each-ref shows correct tracking
+            mock_run.side_effect = [
+                MagicMock(),  # fetch
+                MagicMock(returncode=0),  # rev-parse — branch exists
+                MagicMock(stdout="origin/feature-branch"),  # for-each-ref — correct tracking
+                MagicMock(),  # checkout
+            ]
+            result = runner.invoke(main, ["pr", "checkout", "42"])
+            assert result.exit_code == 0
+            assert "Checked out existing branch feature-branch (tracking origin/feature-branch)" in result.output
+
+    def test_pr_checkout_existing_branch_with_wrong_tracking(self, runner, mock_client, mock_repo):
+        with patch("gitcode_cli.commands.pr.subprocess.run") as mock_run:
+            mock_client.get.return_value = {"number": 42, "head": {"ref": "feature-branch"}}
+            mock_run.side_effect = [
+                MagicMock(),  # fetch
+                MagicMock(returncode=0),  # rev-parse — branch exists
+                MagicMock(stdout="origin/other-branch"),  # for-each-ref — wrong tracking
+            ]
+            result = runner.invoke(main, ["pr", "checkout", "42"])
+            assert result.exit_code != 0
+            assert "already exists" in result.output
+            assert "does not track" in result.output
+
+    def test_pr_checkout_custom_branch_existing_with_correct_tracking(self, runner, mock_client, mock_repo):
+        with patch("gitcode_cli.commands.pr.subprocess.run") as mock_run:
+            mock_client.get.return_value = {"number": 42, "head": {"ref": "feature-branch"}}
+            mock_run.side_effect = [
+                MagicMock(),  # fetch
+                MagicMock(returncode=0),  # rev-parse — custom branch exists
+                MagicMock(stdout="origin/feature-branch"),  # for-each-ref — correct tracking
+                MagicMock(),  # checkout
+            ]
+            result = runner.invoke(main, ["pr", "checkout", "42", "-b", "my-local-feature"])
+            assert result.exit_code == 0
+            assert "Checked out existing branch my-local-feature" in result.output
 
 
 class TestPrReady:
@@ -741,13 +782,10 @@ class TestPrCheckoutEdgeCases:
 
         mock_client.get.return_value = {"number": 42, "head": {"ref": "feature"}}
         with patch("gitcode_cli.commands.pr.subprocess.run") as mock_run:
-            mock_run.side_effect = [
-                MagicMock(),
-                subprocess.CalledProcessError(1, ["git", "checkout"]),
-            ]
+            mock_run.side_effect = subprocess.CalledProcessError(1, ["git", "fetch"])
             result = runner.invoke(main, ["pr", "checkout", "42"])
             assert result.exit_code != 0
-            assert "Git checkout failed" in result.output
+            assert "Git fetch failed" in result.output
 
 
 class TestPrCreateMissingHtmlUrl:

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -669,6 +669,42 @@ class TestPrCheckout:
             assert result.exit_code == 0
             assert "Checked out existing branch my-local-feature" in result.output
 
+    def test_pr_checkout_ignores_matching_tag_when_local_branch_does_not_exist(self, runner, mock_client, mock_repo):
+        with patch("gitcode_cli.commands.pr.subprocess.run") as mock_run:
+            mock_client.get.return_value = {"number": 42, "head": {"ref": "feature-branch"}}
+            mock_run.side_effect = [
+                MagicMock(),  # fetch
+                MagicMock(returncode=1),  # refs/heads/feature-branch does not exist
+                MagicMock(),  # checkout -b
+            ]
+            result = runner.invoke(main, ["pr", "checkout", "42"])
+            assert result.exit_code == 0
+            mock_run.assert_any_call(
+                ["git", "rev-parse", "--verify", "refs/heads/feature-branch"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            mock_run.assert_any_call(
+                ["git", "checkout", "-b", "feature-branch", "origin/feature-branch"],
+                check=True,
+            )
+
+    def test_pr_checkout_existing_branch_checkout_failure_is_wrapped(self, runner, mock_client, mock_repo):
+        import subprocess
+
+        with patch("gitcode_cli.commands.pr.subprocess.run") as mock_run:
+            mock_client.get.return_value = {"number": 42, "head": {"ref": "feature-branch"}}
+            mock_run.side_effect = [
+                MagicMock(),  # fetch
+                MagicMock(returncode=0),  # rev-parse — branch exists
+                MagicMock(stdout="origin/feature-branch"),  # tracking matches
+                subprocess.CalledProcessError(1, ["git", "checkout", "feature-branch"]),
+            ]
+            result = runner.invoke(main, ["pr", "checkout", "42"])
+            assert result.exit_code != 0
+            assert "Git checkout failed" in result.output
+
 
 class TestPrReady:
     def test_pr_ready(self, runner, mock_client, mock_repo):


### PR DESCRIPTION
## Description

Fixes `gc pr checkout` to gracefully handle the case where a local branch already exists with the same name as the PR source branch. Instead of failing with "a branch named X already exists", the command now checks if the existing branch tracks the expected remote ref and reuses it if so.

## Related Issue

Fixes #54

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- `test_pr_checkout` — normal flow (no existing branch)
- `test_pr_checkout_existing_branch_with_correct_tracking` — reuses existing branch
- `test_pr_checkout_existing_branch_with_wrong_tracking` — clear error message
- `test_pr_checkout_custom_branch_existing_with_correct_tracking` — custom `-b` flag with existing branch