### PR TITLE
fix: route pr review comments to comment API

### DIFF
--- a/src/gitcode_cli/adapters/pulls.py
+++ b/src/gitcode_cli/adapters/pulls.py
@@ -91,6 +91,8 @@ class PullRequestAdapter:
         request_changes: bool,
         force: bool,
     ) -> AdapterActionResult:
+        # GitCode's review endpoint is approval-only and does not accept a review body;
+        # comment-style reviews must go through the PR comments endpoint instead.
         if comment:
             item = self.service.comment(owner, repo, number, body=body or "")
             return AdapterActionResult(item=item)

--- a/src/gitcode_cli/adapters/pulls.py
+++ b/src/gitcode_cli/adapters/pulls.py
@@ -87,10 +87,13 @@ class PullRequestAdapter:
         *,
         approve: bool,  # noqa: ARG002
         body: str | None,
-        comment: bool,  # noqa: ARG002
+        comment: bool,
         request_changes: bool,
         force: bool,
     ) -> AdapterActionResult:
+        if comment:
+            item = self.service.comment(owner, repo, number, body=body or "")
+            return AdapterActionResult(item=item)
         if request_changes:
             item = self.service.comment(owner, repo, number, body=body or "")
             return AdapterActionResult(
@@ -98,7 +101,7 @@ class PullRequestAdapter:
                 message=capability_message("PR_REVIEW_REQUEST_CHANGES"),
                 degraded=True,
             )
-        item = self.service.review(owner, repo, number, body=body, force=force)
+        item = self.service.review(owner, repo, number, force=force)
         return AdapterActionResult(item=item)
 
     def edit_pr(

--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -421,6 +421,9 @@ def pr_review(
     if result.degraded:
         safe_echo(f"Posted pull request comment {result.item['id']}")
         raise click.ClickException(result.message or "degraded review operation")
+    if comment:
+        safe_echo(f"Posted pull request comment {result.item['id']}")
+        return
     safe_echo(f"Reviewed pull request #{number}")
 
 

--- a/tests/unit/adapters/test_pulls_adapter.py
+++ b/tests/unit/adapters/test_pulls_adapter.py
@@ -92,12 +92,12 @@ class TestPullRequestAdapter:
             force=False,
         )
 
-        service.review.assert_called_once_with("owner", "repo", 42, body="LGTM", force=False)
+        service.review.assert_called_once_with("owner", "repo", 42, force=False)
         assert result.degraded is False
         assert result.item == {"state": "APPROVED"}
 
-    def test_review_pr_comment_uses_review_api(self, adapter, service):
-        service.review.return_value = {"id": 7}
+    def test_review_pr_comment_uses_comment_api(self, adapter, service):
+        service.comment.return_value = {"id": 7}
 
         result = adapter.review_pr(
             "owner",
@@ -110,7 +110,8 @@ class TestPullRequestAdapter:
             force=False,
         )
 
-        service.review.assert_called_once_with("owner", "repo", 42, body="needs tests", force=False)
+        service.comment.assert_called_once_with("owner", "repo", 42, body="needs tests")
+        service.review.assert_not_called()
         assert result.degraded is False
         assert result.item == {"id": 7}
 

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -501,14 +501,16 @@ class TestPrReview:
         assert "Reviewed pull request #42" in result.output
         mock_resolver.assert_called_once_with(None)
 
-    def test_pr_review_comment_uses_review_api(self, runner, mock_client, mock_repo):
+    def test_pr_review_comment_uses_comment_api(self, runner, mock_client, mock_repo):
         mock_client.post.return_value = {"id": 123}
         result = runner.invoke(main, ["pr", "review", "42", "--comment", "--body", "Needs more tests"])
         assert result.exit_code == 0
-        assert "Reviewed pull request #42" in result.output
+        assert "Posted pull request comment 123" in result.output
         review_calls = [c for c in mock_client.post.call_args_list if "review" in c.args[0]]
-        assert len(review_calls) == 1
-        assert review_calls[0].kwargs["json"]["body"] == "Needs more tests"
+        comment_calls = [c for c in mock_client.post.call_args_list if "comments" in c.args[0]]
+        assert len(review_calls) == 0
+        assert len(comment_calls) == 1
+        assert comment_calls[0].kwargs["json"]["body"] == "Needs more tests"
 
     def test_pr_review_request_changes_downgrades_to_pr_comment_and_explains_it(self, runner, mock_client, mock_repo):
         mock_client.post.return_value = {"id": 456}
@@ -539,7 +541,7 @@ class TestPrReview:
         mock_client.post.return_value = {"id": 123}
         result = runner.invoke(main, ["pr", "review", "42", "--comment", "--body", "Needs more tests"])
         assert result.exit_code == 0
-        assert "Reviewed pull request #42" in result.output
+        assert "Posted pull request comment 123" in result.output
 
     def test_pr_review_request_changes_returns_nonzero_when_downgraded(self, runner, mock_client, mock_repo):
         mock_client.post.return_value = {"id": 456}


### PR DESCRIPTION
## Description

Fixes `gc pr review --comment` so it posts a pull request comment through GitCode's comments endpoint instead of incorrectly calling the approval-only review endpoint. This also updates the success output for comment mode and aligns the unit tests with the corrected behavior.

## Related Issue

Fixes #65

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

Verified by running the full test suite in the worktree: `conda run -n gitcode-cli bash -lc 'cd "/Users/test1/liuyekang/dev/cli/gitcode-cli/.worktrees/fixes-issue-65-pr-review-comment" && pytest -q'`.
Pre-commit hooks also passed during commit creation, including ruff, ruff-format, basedpyright, and pytest.

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [ ] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide