### PR TITLE
test: add layered test architecture for issue #64

### DIFF
--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -23,6 +23,10 @@ def _echo_issue_summary(items: list[dict]) -> None:
         safe_echo(output)
 
 
+def _pending_gh_compat(name: str) -> None:
+    raise click.ClickException(f"gh-compatible command/flag '{name}' is recognized but not implemented yet.")
+
+
 @click.group("issue")
 def issue_group() -> None:
     pass
@@ -36,6 +40,7 @@ def issue_group() -> None:
 @click.option("-a", "--assignee")
 @click.option("--milestone")
 @click.option("--mention")
+@click.option("--app")
 @click.option("-S", "--search")
 @click.option("-L", "--limit", type=int, default=30, show_default=True, help="Maximum number of items to fetch.")
 @click.option("-w", "--web", is_flag=True, help="Open the issue list in the web browser.")
@@ -52,6 +57,7 @@ def issue_list(
     assignee: str | None,
     milestone: str | None,
     mention: str | None,
+    app: str | None,
     search: str | None,
     limit: int | None,
     web: bool,
@@ -59,14 +65,16 @@ def issue_list(
     jq_query: str | None,
     template: str | None,
 ) -> None:
-    app = ctx.obj["app"]
-    owner, repo = resolve_repo(repo_name or app.repo)
+    app_ctx = ctx.obj["app"]
+    owner, repo = resolve_repo(repo_name or app_ctx.repo)
     if limit is not None and limit < 1:
         raise click.BadParameter("must be greater than 0", param_hint="--limit")
+    if app is not None:
+        _pending_gh_compat("issue list --app")
     if web:
         open_in_browser(f"https://gitcode.com/{owner}/{repo}/issues")
         return
-    service = IssueService(app.client())
+    service = IssueService(app_ctx.client())
     adapter = IssueAdapter(service)
     items = adapter.list_issues(
         owner,
@@ -156,6 +164,7 @@ def issue_view(
 @click.option("-t", "--title")
 @click.option("-b", "--body")
 @click.option("-a", "--assignee")
+@click.option("-e", "--editor", is_flag=True)
 @click.option("-l", "--label", "labels", multiple=True)
 @click.option("-m", "--milestone")
 @click.option("-F", "--body-file")
@@ -170,6 +179,7 @@ def issue_create(
     title: str | None,
     body: str | None,
     assignee: str | None,
+    editor: bool,
     labels: tuple[str, ...] | None,
     milestone: str | None,
     body_file: str | None,
@@ -184,6 +194,8 @@ def issue_create(
         open_in_browser(f"https://gitcode.com/{owner}/{repo}/issues/new")
         return
     title = prompt_if_missing(title, "Title")
+    if editor:
+        _pending_gh_compat("issue create --editor")
     if len(title) > 255:
         raise click.ClickException("title must be 255 characters or fewer")
     body = get_body_from_options(body=body, body_file=body_file, editor=False)
@@ -211,6 +223,7 @@ def issue_create(
 @click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.argument("identifier")
 @click.option("-c", "--comment", help="Leave a closing comment.")
+@click.option("--duplicate-of")
 @click.option("-r", "--reason", type=click.Choice(["completed", "not_planned"]), help="Reason for closing.")
 @click.pass_context
 def issue_close(
@@ -218,6 +231,7 @@ def issue_close(
     repo_name: str | None,
     identifier: str,
     comment: str | None,
+    duplicate_of: str | None,
     reason: str | None,
 ) -> None:
     app = ctx.obj["app"]
@@ -227,6 +241,8 @@ def issue_close(
         owner, repo = url_owner, url_repo
     else:
         owner, repo = resolve_repo(repo_name or app.repo)
+    if duplicate_of is not None:
+        _pending_gh_compat("issue close --duplicate-of")
     service = IssueService(app.client())
     adapter = IssueAdapter(service)
     result = adapter.close_issue(owner, repo, number, comment=comment, reason=reason)
@@ -244,8 +260,12 @@ def issue_close(
 @click.argument("identifier")
 @click.option("-b", "--body")
 @click.option("-F", "--body-file")
+@click.option("--create-if-none", is_flag=True)
+@click.option("--delete-last", is_flag=True)
+@click.option("--edit-last", is_flag=True)
 @click.option("-e", "--editor", is_flag=True)
 @click.option("-w", "--web", is_flag=True)
+@click.option("--yes", is_flag=True)
 @click.pass_context
 def issue_comment(
     ctx: click.Context,
@@ -253,8 +273,12 @@ def issue_comment(
     identifier: str,
     body: str | None,
     body_file: str | None,
+    create_if_none: bool,
+    delete_last: bool,
+    edit_last: bool,
     editor: bool,
     web: bool,
+    yes: bool,
 ) -> None:
     app = ctx.obj["app"]
     url_owner, url_repo, number = resolve_issue_arg(identifier)
@@ -267,6 +291,8 @@ def issue_comment(
         target_url = identifier if url_owner else f"https://gitcode.com/{owner}/{repo}/issues/{number}"
         open_in_browser(target_url)
         return
+    if create_if_none or delete_last or edit_last or yes:
+        _pending_gh_compat("issue comment history-management flags")
     body = get_body_from_options(body=body, body_file=body_file, editor=editor)
     if editor and body is None:
         raise click.ClickException("Editor was closed without saving a comment.")

--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -193,9 +193,9 @@ def issue_create(
     if web:
         open_in_browser(f"https://gitcode.com/{owner}/{repo}/issues/new")
         return
-    title = prompt_if_missing(title, "Title")
     if editor:
         _pending_gh_compat("issue create --editor")
+    title = prompt_if_missing(title, "Title")
     if len(title) > 255:
         raise click.ClickException("title must be 255 characters or fewer")
     body = get_body_from_options(body=body, body_file=body_file, editor=False)

--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -26,6 +26,10 @@ from ..utils import (
 )
 
 
+def _pending_gh_compat(name: str) -> None:
+    raise click.ClickException(f"gh-compatible command/flag '{name}' is recognized but not implemented yet.")
+
+
 @click.group("pr")
 def pr_group() -> None:
     pass
@@ -36,9 +40,9 @@ def pr_group() -> None:
 @click.option("-s", "--state")
 @click.option("-A", "--author")
 @click.option("-B", "--base")
-@click.option("--assignee")
-@click.option("--draft", is_flag=True, default=None)
-@click.option("--head")
+@click.option("-a", "--assignee")
+@click.option("-d", "--draft", is_flag=True, default=None)
+@click.option("-H", "--head")
 @click.option("-l", "--label", "labels", multiple=True)
 @click.option("-S", "--search")
 @click.option("-L", "--limit", type=int, default=30, show_default=True, help="Maximum number of items to fetch.")
@@ -162,15 +166,15 @@ def pr_view(
 @click.option("-t", "--title")
 @click.option("-b", "--body")
 @click.option("-F", "--body-file")
-@click.option("--editor", is_flag=True)
-@click.option("--fill", is_flag=True, help="Use commit info for title and body.")
+@click.option("-e", "--editor", is_flag=True)
+@click.option("-f", "--fill", is_flag=True, help="Use commit info for title and body.")
 @click.option("--fill-first", is_flag=True, help="Use first commit info for title and body.")
 @click.option("--fill-verbose", is_flag=True, help="Use all commits for body description.")
 @click.option("--dry-run", is_flag=True)
 @click.option("-B", "--base")
 @click.option("-H", "--head")
 @click.option("-d", "--draft", is_flag=True)
-@click.option("--milestone")
+@click.option("-m", "--milestone")
 @click.option("-l", "--label", "labels", multiple=True)
 @click.option("-r", "--reviewer", "reviewers", multiple=True)
 @click.option("-a", "--assignee", "assignees", multiple=True)
@@ -204,6 +208,8 @@ def pr_create(
 ) -> None:
     app = ctx.obj["app"]
     owner, repo = resolve_repo(repo_name or app.repo)
+    if editor:
+        _pending_gh_compat("pr create --editor")
     if web:
         open_in_browser(f"https://gitcode.com/{owner}/{repo}/pulls/new")
         return
@@ -303,6 +309,12 @@ def pr_close(
 @click.option("-s", "--squash", is_flag=True, help="Squash the pull request.")
 @click.option("-r", "--rebase", is_flag=True, help="Rebase the pull request.")
 @click.option("-d", "--delete-branch", is_flag=True, help="Delete the remote branch after merge.")
+@click.option("-b", "--body")
+@click.option("-F", "--body-file")
+@click.option("-t", "--subject")
+@click.option("-A", "--author-email")
+@click.option("--auto", is_flag=True)
+@click.option("--admin", is_flag=True)
 @click.pass_context
 def pr_merge(
     ctx: click.Context,
@@ -312,9 +324,17 @@ def pr_merge(
     squash: bool,
     rebase: bool,
     delete_branch: bool,
+    body: str | None,
+    body_file: str | None,
+    subject: str | None,
+    author_email: str | None,
+    auto: bool,
+    admin: bool,
 ) -> None:
     app = ctx.obj["app"]
     owner, repo = resolve_repo(repo_name or app.repo)
+    if any(value is not None for value in (body, body_file, subject, author_email)) or auto or admin:
+        _pending_gh_compat("pr merge advanced gh flags")
     service = PullRequestService(app.client())
     resolved_identifier = resolve_pr_identifier_or_current_branch(identifier)
     owner, repo, number = resolve_pr_arg(resolved_identifier, owner, repo, service)
@@ -379,9 +399,10 @@ def pr_comment(
 @click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.argument("identifier", required=False)
 @click.option("-a", "--approve", is_flag=True, help="Approve the pull request. GitCode maps this to its review API.")
-@click.option("--body")
-@click.option("--comment", is_flag=True, help="Leave a review comment.")
-@click.option("--request-changes", is_flag=True, help="Request changes. Downgrades to a PR comment on GitCode.")
+@click.option("-b", "--body")
+@click.option("-F", "--body-file")
+@click.option("-c", "--comment", is_flag=True, help="Leave a review comment.")
+@click.option("-r", "--request-changes", is_flag=True, help="Request changes. Downgrades to a PR comment on GitCode.")
 @click.option("--force", is_flag=True, help="Force review handling when supported by GitCode.")
 @click.pass_context
 def pr_review(
@@ -390,6 +411,7 @@ def pr_review(
     identifier: str | None,
     approve: bool,
     body: str | None,
+    body_file: str | None,
     comment: bool,
     request_changes: bool,
     force: bool,
@@ -400,6 +422,9 @@ def pr_review(
     resolved_identifier = resolve_pr_identifier_or_current_branch(identifier)
     owner, repo, number = resolve_pr_arg(resolved_identifier, owner, repo, service)
     number = int(number)
+
+    if body_file is not None:
+        _pending_gh_compat("pr review --body-file")
 
     selected_modes = [approve, comment, request_changes]
     if sum(1 for selected in selected_modes if selected) != 1:

--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -208,8 +208,6 @@ def pr_create(
 ) -> None:
     app = ctx.obj["app"]
     owner, repo = resolve_repo(repo_name or app.repo)
-    if editor:
-        _pending_gh_compat("pr create --editor")
     if web:
         open_in_browser(f"https://gitcode.com/{owner}/{repo}/pulls/new")
         return

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,7 @@ This test suite mirrors the `gc` architecture so failures can be isolated by lay
 - `unit/test_cli.py` and `unit/commands/`: CLI and command behavior, including argument parsing, exit behavior, and command-to-adapter delegation.
 - `unit/adapters/`: translation from `gh`-style command semantics into GitCode-compatible service calls, including degraded or approximated behavior.
 - `unit/services/`: low-level GitCode API request construction, including HTTP method, path, and request payload filtering.
-- `contracts/`: contract checks against extracted GitCode API docs under `.claude/skills/gitcode-docs/output/gitcode-api/raw/`.
+- `contracts/`: contract checks against extracted GitCode API docs under `tests/fixtures/gitcode-api-contracts/raw/`.
 
 ## Why this split exists
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,30 @@
+# Tests
+
+This test suite mirrors the `gc` architecture so failures can be isolated by layer.
+
+## Layers
+
+- `unit/test_cli.py` and `unit/commands/`: CLI and command behavior, including argument parsing, exit behavior, and command-to-adapter delegation.
+- `unit/adapters/`: translation from `gh`-style command semantics into GitCode-compatible service calls, including degraded or approximated behavior.
+- `unit/services/`: low-level GitCode API request construction, including HTTP method, path, and request payload filtering.
+- `contracts/`: contract checks against extracted GitCode API docs under `.claude/skills/gitcode-docs/output/gitcode-api/raw/`.
+
+## Why this split exists
+
+The CLI aims to feel `gh`-compatible while still speaking GitCode's API correctly. Keeping tests split by layer makes it easier to tell whether a regression comes from command UX, adapter translation, service request construction, or API contract drift.
+
+## Running tests
+
+Run the full suite:
+
+```bash
+conda run -n gitcode-cli python -m pytest tests
+```
+
+Run one layer:
+
+```bash
+conda run -n gitcode-cli python -m pytest tests/unit/adapters
+conda run -n gitcode-cli python -m pytest tests/unit/services
+conda run -n gitcode-cli python -m pytest tests/contracts
+```

--- a/tests/contracts/test_gitcode_api_contracts.py
+++ b/tests/contracts/test_gitcode_api_contracts.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from gitcode_cli.services.issues import IssueService
+from gitcode_cli.services.pulls import PullRequestService
+
+RAW_DOCS_RELATIVE_PATH = Path(".claude/skills/gitcode-docs/output/gitcode-api/raw")
+
+
+def _find_raw_docs_root() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / RAW_DOCS_RELATIVE_PATH
+        if candidate.exists():
+            return candidate
+    pytest.fail(f"Could not locate extracted GitCode API docs under {RAW_DOCS_RELATIVE_PATH}")
+
+
+def _load_contract(*parts: str) -> dict:
+    contract_path = _find_raw_docs_root().joinpath(*parts)
+    return json.loads(contract_path.read_text(encoding="utf-8"))
+
+
+def _contract_path(contract: dict, **path_params: str | int) -> str:
+    return contract["path"].format(**path_params).removeprefix("/api/v5")
+
+
+@pytest.fixture
+def issue_service() -> tuple[IssueService, MagicMock]:
+    client = MagicMock()
+    return IssueService(client), client
+
+
+@pytest.fixture
+def pull_service() -> tuple[PullRequestService, MagicMock]:
+    client = MagicMock()
+    return PullRequestService(client), client
+
+
+class TestIssueServiceContracts:
+    def test_list_matches_issue_list_contract(self, issue_service: tuple[IssueService, MagicMock]) -> None:
+        service, client = issue_service
+        contract = _load_contract("Issues", "get-api-v-5-repos-owner-repo-issues.json")
+
+        service.list("owner", "repo", state="open", per_page=10)
+
+        client.get.assert_called_once_with(
+            _contract_path(contract, owner="owner", repo="repo"),
+            params={"state": "open", "per_page": 10},
+        )
+        assert contract["method"] == "GET"
+
+    def test_get_matches_issue_get_contract(self, issue_service: tuple[IssueService, MagicMock]) -> None:
+        service, client = issue_service
+        contract = _load_contract("Issues", "get-api-v-5-repos-owner-repo-issues-number.json")
+
+        service.get("owner", "repo", "42")
+
+        client.get.assert_called_once_with(_contract_path(contract, owner="owner", repo="repo", number="42"))
+        assert contract["method"] == "GET"
+
+    def test_list_comments_matches_issue_comment_list_contract(
+        self, issue_service: tuple[IssueService, MagicMock]
+    ) -> None:
+        service, client = issue_service
+        contract = _load_contract("Issues", "get-api-v-5-repos-owner-repo-issues-number-comments.json")
+
+        service.list_comments("owner", "repo", "42")
+
+        client.get.assert_called_once_with(_contract_path(contract, owner="owner", repo="repo", number="42"))
+        assert contract["method"] == "GET"
+
+    def test_create_matches_issue_create_contract(self, issue_service: tuple[IssueService, MagicMock]) -> None:
+        service, client = issue_service
+        contract = _load_contract("Issues", "post-api-v-5-repos-owner-issues.json")
+
+        service.create("owner", "repo", title="Bug", body="Broken", assignee=None, labels="bug")
+
+        client.post.assert_called_once_with(
+            _contract_path(contract, owner="owner"),
+            json={"repo": "repo", "title": "Bug", "body": "Broken", "labels": "bug"},
+        )
+        assert contract["method"] == "POST"
+        request_fields = {field["name"] for field in contract["requestBodyFields"]}
+        assert {"repo", "title", "body", "labels"}.issubset(request_fields)
+
+    def test_update_matches_issue_update_contract(self, issue_service: tuple[IssueService, MagicMock]) -> None:
+        service, client = issue_service
+        contract = _load_contract("Issues", "patch-api-v-5-repos-owner-issues-number.json")
+
+        service.update(
+            "owner",
+            "repo",
+            "42",
+            title="Updated",
+            state="close",
+            state_reason="completed",
+            milestone=None,
+        )
+
+        client.patch.assert_called_once_with(
+            _contract_path(contract, owner="owner", number="42"),
+            json={"repo": "repo", "title": "Updated", "state": "close", "state_reason": "completed"},
+        )
+        assert contract["method"] == "PATCH"
+        request_fields = {field["name"] for field in contract["requestBodyFields"]}
+        assert {"repo", "title", "state"}.issubset(request_fields)
+
+    def test_comment_matches_issue_comment_create_contract(self, issue_service: tuple[IssueService, MagicMock]) -> None:
+        service, client = issue_service
+        contract = _load_contract("Issues", "post-api-v-5-repos-owner-repo-issues-number-comments.json")
+
+        service.comment("owner", "repo", "42", "Nice issue")
+
+        client.post.assert_called_once_with(
+            _contract_path(contract, owner="owner", repo="repo", number="42"),
+            json={"body": "Nice issue"},
+        )
+        assert contract["method"] == "POST"
+        request_fields = {field["name"] for field in contract["requestBodyFields"]}
+        assert "body" in request_fields
+
+
+class TestPullRequestServiceContracts:
+    def test_list_matches_pr_list_contract(self, pull_service: tuple[PullRequestService, MagicMock]) -> None:
+        service, client = pull_service
+        contract = _load_contract("Pull Requests", "get-api-v-5-repos-owner-repo-pulls.json")
+
+        service.list("owner", "repo", state="open")
+
+        client.get.assert_called_once_with(
+            _contract_path(contract, owner="owner", repo="repo"), params={"state": "open"}
+        )
+        assert contract["method"] == "GET"
+
+    def test_get_matches_pr_get_contract(self, pull_service: tuple[PullRequestService, MagicMock]) -> None:
+        service, client = pull_service
+        contract = _load_contract("Pull Requests", "get-api-v-5-repos-owner-repo-pulls-number.json")
+
+        service.get("owner", "repo", 42)
+
+        client.get.assert_called_once_with(_contract_path(contract, owner="owner", repo="repo", number=42))
+        assert contract["method"] == "GET"
+
+    def test_create_matches_pr_create_contract(self, pull_service: tuple[PullRequestService, MagicMock]) -> None:
+        service, client = pull_service
+        contract = _load_contract("Pull Requests", "post-api-v-5-repos-owner-repo-pulls.json")
+
+        service.create("owner", "repo", title="Feature", head="feature", base="main", body=None, labels="bug")
+
+        client.post.assert_called_once_with(
+            _contract_path(contract, owner="owner", repo="repo"),
+            json={"title": "Feature", "head": "feature", "base": "main", "labels": "bug"},
+        )
+        assert contract["method"] == "POST"
+        request_fields = {field["name"] for field in contract["requestBodyFields"]}
+        assert {"title", "head", "base", "labels"}.issubset(request_fields)
+
+    def test_update_matches_pr_update_contract(self, pull_service: tuple[PullRequestService, MagicMock]) -> None:
+        service, client = pull_service
+        contract = _load_contract("Pull Requests", "patch-api-v-5-repos-owner-repo-pulls-number.json")
+
+        service.update("owner", "repo", 42, title="Updated", state="closed", reviewer=None)
+
+        client.patch.assert_called_once_with(
+            _contract_path(contract, owner="owner", repo="repo", number=42),
+            json={"title": "Updated", "state": "closed"},
+        )
+        assert contract["method"] == "PATCH"
+        request_fields = {field["name"] for field in contract["requestBodyFields"]}
+        assert {"title", "state"}.issubset(request_fields)
+
+    def test_merge_matches_pr_merge_contract(self, pull_service: tuple[PullRequestService, MagicMock]) -> None:
+        service, client = pull_service
+        contract = _load_contract("Pull Requests", "put-api-v-5-repos-owner-repo-pulls-number-merge.json")
+
+        service.merge("owner", "repo", 42, merge_method="squash")
+
+        client.put.assert_called_once_with(
+            _contract_path(contract, owner="owner", repo="repo", number=42),
+            json={"merge_method": "squash"},
+        )
+        assert contract["method"] == "PUT"
+
+    def test_comment_matches_pr_comment_contract(self, pull_service: tuple[PullRequestService, MagicMock]) -> None:
+        service, client = pull_service
+        contract = _load_contract("Pull Requests", "post-api-v-5-repos-owner-repo-pulls-number-comments.json")
+
+        service.comment("owner", "repo", 42, "Fix this", path="main.py", position=7)
+
+        client.post.assert_called_once_with(
+            _contract_path(contract, owner="owner", repo="repo", number=42),
+            json={"body": "Fix this", "path": "main.py", "position": 7},
+        )
+        assert contract["method"] == "POST"
+        request_fields = {field["name"] for field in contract["requestBodyFields"]}
+        assert {"body", "path", "position"}.issubset(request_fields)
+
+    def test_review_matches_pr_review_contract(self, pull_service: tuple[PullRequestService, MagicMock]) -> None:
+        service, client = pull_service
+        contract = _load_contract("Pull Requests", "post-api-v-5-repos-owner-repo-pulls-number-review.json")
+
+        service.review("owner", "repo", 42, body=None, force=True)
+
+        client.post.assert_called_once_with(
+            _contract_path(contract, owner="owner", repo="repo", number=42),
+            json={"force": True},
+        )
+        assert contract["method"] == "POST"
+        request_fields = {field["name"] for field in contract["requestBodyFields"]}
+        assert "force" in request_fields
+
+    def test_list_comments_matches_pr_comment_list_contract(
+        self, pull_service: tuple[PullRequestService, MagicMock]
+    ) -> None:
+        service, client = pull_service
+        contract = _load_contract("Pull Requests", "get-api-v-5-repos-owner-repo-pulls-number-comments.json")
+
+        service.list_comments("owner", "repo", 42)
+
+        client.get.assert_called_once_with(_contract_path(contract, owner="owner", repo="repo", number=42))
+        assert contract["method"] == "GET"

--- a/tests/contracts/test_gitcode_api_contracts.py
+++ b/tests/contracts/test_gitcode_api_contracts.py
@@ -9,7 +9,7 @@ import pytest
 from gitcode_cli.services.issues import IssueService
 from gitcode_cli.services.pulls import PullRequestService
 
-RAW_DOCS_RELATIVE_PATH = Path(".claude/skills/gitcode-docs/output/gitcode-api/raw")
+RAW_DOCS_RELATIVE_PATH = Path("tests/fixtures/gitcode-api-contracts/raw")
 
 
 def _find_raw_docs_root() -> Path:

--- a/tests/fixtures/gh-cli-compat/command_baseline.json
+++ b/tests/fixtures/gh-cli-compat/command_baseline.json
@@ -1,0 +1,48 @@
+{
+  "issue": {
+    "subcommands": ["list", "view", "create", "close", "comment"],
+    "commands": {
+      "issue list": {
+        "flags": ["-s", "-l", "-A", "-a", "--milestone", "--mention", "--app", "-S", "-L", "-w", "--json", "-q", "-t", "-R"]
+      },
+      "issue view": {
+        "flags": ["-c", "-w", "--json", "-q", "-t", "-R"]
+      },
+      "issue create": {
+        "flags": ["-t", "-b", "-F", "-e", "-l", "-m", "-a", "-w", "-R"]
+      },
+      "issue close": {
+        "flags": ["-c", "-r", "--duplicate-of", "-R"]
+      },
+      "issue comment": {
+        "flags": ["-b", "-F", "-e", "-w", "--delete-last", "--edit-last", "-R"]
+      }
+    }
+  },
+  "pr": {
+    "subcommands": ["list", "view", "create", "close", "merge", "comment", "review"],
+    "commands": {
+      "pr list": {
+        "flags": ["-s", "-A", "-B", "-a", "-d", "-H", "-l", "-S", "-L", "-w", "--json", "-q", "-t", "-R"]
+      },
+      "pr view": {
+        "flags": ["-c", "-w", "--json", "-q", "-t", "-R"]
+      },
+      "pr create": {
+        "flags": ["-t", "-b", "-F", "-e", "-f", "-d", "-B", "-H", "-l", "-r", "-a", "-m", "-w", "--json", "-q", "-R", "--dry-run"]
+      },
+      "pr close": {
+        "flags": ["-c", "-d", "-R"]
+      },
+      "pr merge": {
+        "flags": ["-m", "-s", "-r", "-d", "-b", "-F", "-t", "-A", "--auto", "--admin", "-R"]
+      },
+      "pr comment": {
+        "flags": ["-b", "-F", "-e", "-w", "-R"]
+      },
+      "pr review": {
+        "flags": ["-a", "-b", "-F", "-c", "-r", "-R"]
+      }
+    }
+  }
+}

--- a/tests/fixtures/gitcode-api-contracts/raw/Issues/get-api-v-5-repos-owner-repo-issues-number-comments.json
+++ b/tests/fixtures/gitcode-api-contracts/raw/Issues/get-api-v-5-repos-owner-repo-issues-number-comments.json
@@ -1,0 +1,232 @@
+{
+  "category": "Issues",
+  "name": "获取仓库某个Issue所有的评论",
+  "slug": "get-api-v-5-repos-owner-repo-issues-number-comments",
+  "docUrl": "https://docs.gitcode.com/docs/apis/get-api-v-5-repos-owner-repo-issues-number-comments",
+  "summary": "",
+  "method": "GET",
+  "path": "/api/v5/repos/{owner}/{repo}/issues/{number}/comments",
+  "pathParams": [
+    {
+      "name": "owner",
+      "type": "string",
+      "required": true,
+      "description": "仓库所属空间地址(企业、组织或个人的地址path)"
+    },
+    {
+      "name": "repo",
+      "type": "string",
+      "required": true,
+      "description": "仓库路径(path)"
+    },
+    {
+      "name": "number",
+      "type": "string",
+      "required": true,
+      "description": "Issue 编号(区分大小写，无需添加 # 号)"
+    }
+  ],
+  "queryParams": [
+    {
+      "name": "access_token",
+      "type": "string",
+      "required": true,
+      "description": "用户授权码"
+    },
+    {
+      "name": "page",
+      "type": "integer",
+      "required": false,
+      "description": "当前的页码"
+    },
+    {
+      "name": "per_page",
+      "type": "integer",
+      "required": false,
+      "description": "每页的数量，最大为 100，默认 20"
+    },
+    {
+      "name": "order",
+      "type": "string",
+      "required": false,
+      "description": "排序顺序: asc(default),desc"
+    },
+    {
+      "name": "since",
+      "type": "string",
+      "required": false,
+      "description": "起始的更新时间，要求时间格式为 2024-11-10T08:10:30.000+08:00（注意+号要url编码为%2B）"
+    }
+  ],
+  "requestBodyFields": [],
+  "responseFields": [
+    {
+      "name": "items[].id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].body",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.events_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "items[].user.followers_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "items[].user.following_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "items[].user.gists_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "items[].user.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.member_role",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "items[].user.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.organizations_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "items[].user.received_events_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "items[].user.remark",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "items[].user.repos_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "items[].user.starred_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "items[].user.subscriptions_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "items[].user.type",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "items[].user.url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "items[].target.issue.id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].target.issue.title",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].target.issue.nubmer",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].updated_at",
+      "type": "string",
+      "description": ""
+    }
+  ],
+  "responseExample": {
+    "id": 271624,
+    "body": "评论内容。",
+    "user": {
+      "avatar_url": "https://gitcode-img.obs.cn-south-1.myhuaweicloud.com:443/fa/fe/f32a9fecc53e890afbd48fd098b0f6c5f20f062581400c76c85e5baab3f0d5b2.png",
+      "events_url": null,
+      "followers_url": null,
+      "following_url": null,
+      "gists_url": null,
+      "html_url": "https://test.gitcode.net/dengmengmian",
+      "id": "661ce4eab470b1430d456154",
+      "login": "dengmengmian",
+      "member_role": null,
+      "name": "麻凡_",
+      "organizations_url": null,
+      "received_events_url": null,
+      "remark": null,
+      "repos_url": null,
+      "starred_url": null,
+      "subscriptions_url": null,
+      "type": null,
+      "url": null
+    },
+    "target": {
+      "issue": {
+        "id": 152134,
+        "title": "",
+        "nubmer": 1
+      }
+    },
+    "created_at": "2024-04-19T17:50:18.199+08:00",
+    "updated_at": "2024-04-19T17:50:18.199+08:00"
+  },
+  "curlExample": "curl -X GET \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/issues/number_value/comments?access_token=YOUR_TOKEN\" \\\\\n  -H \"Accept: application/json\"",
+  "pythonExample": "import requests\n\nurl = \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/issues/number_value/comments\"\nparams = {\"access_token\": \"YOUR_TOKEN\"}\nheaders = {\"Accept\": \"application/json\"}\ndata = {}\n\nresponse = requests.get(url, headers=headers, params=params, json=data)\nprint(response.json())",
+  "dataSource": "frontMatter.api",
+  "status": "done",
+  "notes": "requestBody omitted in source",
+  "metadata": {
+    "chunkUrl": "https://docs.gitcode.com/assets/js/12d3a1c9.6f6f4b78.js",
+    "sourceType": "openapi",
+    "titleFrom": "metadata.title"
+  }
+}

--- a/tests/fixtures/gitcode-api-contracts/raw/Issues/get-api-v-5-repos-owner-repo-issues-number.json
+++ b/tests/fixtures/gitcode-api-contracts/raw/Issues/get-api-v-5-repos-owner-repo-issues-number.json
@@ -1,0 +1,375 @@
+{
+  "category": "Issues",
+  "name": "获取仓库的某个Issue",
+  "slug": "get-api-v-5-repos-owner-repo-issues-number",
+  "docUrl": "https://docs.gitcode.com/docs/apis/get-api-v-5-repos-owner-repo-issues-number",
+  "summary": "",
+  "method": "GET",
+  "path": "/api/v5/repos/{owner}/{repo}/issues/{number}",
+  "pathParams": [
+    {
+      "name": "owner",
+      "type": "string",
+      "required": true,
+      "description": "仓库所属空间地址(组织或个人的地址path)"
+    },
+    {
+      "name": "repo",
+      "type": "string",
+      "required": true,
+      "description": "仓库路径(path)"
+    },
+    {
+      "name": "number",
+      "type": "string",
+      "required": true,
+      "description": "Issue 编号(区分大小写，无需添加 # 号)"
+    }
+  ],
+  "queryParams": [
+    {
+      "name": "access_token",
+      "type": "string",
+      "required": true,
+      "description": "用户授权码"
+    }
+  ],
+  "requestBodyFields": [],
+  "responseFields": [
+    {
+      "name": "id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "number",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "title",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "body",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "repository.id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "repository.full_name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "repository.path",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "repository.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "repository.description",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "repository.created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "repository.updated_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "repository.assigner",
+      "type": "object",
+      "description": ""
+    },
+    {
+      "name": "repository.paas",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "updated_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "finished_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "labels[].id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "labels[].name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "labels[].color",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "labels[].created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "labels[].updated_at",
+      "type": "string",
+      "description": "label添加时间"
+    },
+    {
+      "name": "issue_state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "comments",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "priority",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "issue_type",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "issue_state_detail.title",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "issue_state_detail.serial",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "issue_state_detail.id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "issue_type_detail.title",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "issue_type_detail.id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "issue_type_detail.is_system",
+      "type": "boolean",
+      "description": ""
+    },
+    {
+      "name": "issue_priority_detail.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "issue_priority_detail.title",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "milestone.created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "milestone.description",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "milestone.due_on",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "milestone.number",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "milestone.repository_id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "milestone.state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "milestone.title",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "milestone.updated_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "milestone.url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "custom_fields[].field_name",
+      "type": "string",
+      "description": "自定义字段名称"
+    },
+    {
+      "name": "custom_fields[].field_type",
+      "type": "string",
+      "description": "自定义字段的类型。text_single：单行文本，text_multi：多行文本，integer：整数，decimal：小数，date：日期，select_single：单选下拉，select_multi：多选下拉，member_single：单选成员，member_multi：多选成员"
+    },
+    {
+      "name": "custom_fields[].field_visibility",
+      "type": "string",
+      "description": "可见性。0：仅管理员可见，1：所有人可见"
+    },
+    {
+      "name": "custom_fields[].field_values[]",
+      "type": "array<string>",
+      "description": "自定义字段的值"
+    },
+    {
+      "name": "visibility_reason",
+      "type": "string",
+      "description": "可见性，public：公开可见，confidential：私密，项目成员可见，other：其他原因导致的仅项目成员可见"
+    }
+  ],
+  "responseExample": {
+    "id": 152212,
+    "html_url": "https://test.gitcode.net/dengmengmian/test01/issues/3",
+    "number": 3,
+    "state": "opened",
+    "title": "查员种金交片",
+    "body": "而很资七图数指反系并物众示易今高。运边月发红条亲才调二心点上米面世其分。由众计比维选作小指件每酸一见基历。向九又中国层合感内两米或自很转的。",
+    "user": {
+      "avatar_url": "https://gitcode-img.obs.cn-south-1.myhuaweicloud.com:443/fa/fe/f32a9fecc53e890afbd48fd098b0f6c5f20f062581400c76c85e5baab3f0d5b2.png",
+      "events_url": null,
+      "followers_url": null,
+      "following_url": null,
+      "gists_url": null,
+      "html_url": "https://test.gitcode.net/dengmengmian",
+      "id": "661ce4eab470b1430d456154",
+      "login": "dengmengmian",
+      "member_role": null,
+      "name": "麻凡_",
+      "organizations_url": null,
+      "received_events_url": null,
+      "remark": null,
+      "repos_url": null,
+      "starred_url": null,
+      "subscriptions_url": null,
+      "type": null,
+      "url": null
+    },
+    "assignee": null,
+    "repository": {
+      "id": 280713,
+      "full_name": "dengmengmian / test01",
+      "path": "test01",
+      "name": "test01",
+      "description": "",
+      "created_at": "2024-04-15T16:27:45.090+08:00",
+      "updated_at": "2024-04-15T16:27:45.090+08:00",
+      "assigner": null,
+      "pushed_at": null,
+      "paas": null,
+      "assignees_number": null,
+      "testers_number": null,
+      "assignee": null,
+      "testers": null
+    },
+    "created_at": "2024-04-15T21:58:21.188+08:00",
+    "updated_at": "2024-04-15T21:58:21.188+08:00",
+    "finished_at": null,
+    "labels": [],
+    "priority": null,
+    "issue_type": null,
+    "issue_state": "opened",
+    "issue_state_detail": null,
+    "stage": "New",
+    "severity": "Major"
+  },
+  "curlExample": "curl -X GET \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/issues/number_value?access_token=YOUR_TOKEN\" \\\\\n  -H \"Accept: application/json\"",
+  "pythonExample": "import requests\n\nurl = \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/issues/number_value\"\nparams = {\"access_token\": \"YOUR_TOKEN\"}\nheaders = {\"Accept\": \"application/json\"}\ndata = {}\n\nresponse = requests.get(url, headers=headers, params=params, json=data)\nprint(response.json())",
+  "dataSource": "frontMatter.api",
+  "status": "done",
+  "notes": "requestBody omitted in source",
+  "metadata": {
+    "chunkUrl": "https://docs.gitcode.com/assets/js/1687b17e.0144a92d.js",
+    "sourceType": "openapi",
+    "titleFrom": "metadata.title"
+  }
+}

--- a/tests/fixtures/gitcode-api-contracts/raw/Issues/get-api-v-5-repos-owner-repo-issues.json
+++ b/tests/fixtures/gitcode-api-contracts/raw/Issues/get-api-v-5-repos-owner-repo-issues.json
@@ -1,0 +1,503 @@
+{
+  "category": "Issues",
+  "name": "获取仓库所有 issues",
+  "slug": "get-api-v-5-repos-owner-repo-issues",
+  "docUrl": "https://docs.gitcode.com/docs/apis/get-api-v-5-repos-owner-repo-issues",
+  "summary": "",
+  "method": "GET",
+  "path": "/api/v5/repos/{owner}/{repo}/issues",
+  "pathParams": [
+    {
+      "name": "owner",
+      "type": "string",
+      "required": true,
+      "description": "仓库所属空间地址(组织或个人的地址path)"
+    },
+    {
+      "name": "repo",
+      "type": "string",
+      "required": true,
+      "description": "仓库路径(path)"
+    }
+  ],
+  "queryParams": [
+    {
+      "name": "access_token",
+      "type": "string",
+      "required": true,
+      "description": "用户授权码"
+    },
+    {
+      "name": "state",
+      "type": "string",
+      "required": false,
+      "description": "Issue的状态: open（开启的）, closed（关闭的）， all (所有)。 默认: all"
+    },
+    {
+      "name": "labels",
+      "type": "string",
+      "required": false,
+      "description": "用逗号分开的标签。如: bug,performance"
+    },
+    {
+      "name": "sort",
+      "type": "string",
+      "required": false,
+      "description": "排序依据: 创建时间(created)，更新时间(updated)。默认: created"
+    },
+    {
+      "name": "direction",
+      "type": "string",
+      "required": false,
+      "description": "排序方式: 升序(asc)，降序(desc)。默认: desc"
+    },
+    {
+      "name": "since",
+      "type": "string",
+      "required": false,
+      "description": "起始的更新时间，要求时间格式为 2024-11-10T08:10:30.000+08:00（注意+号要url编码为%2B）"
+    },
+    {
+      "name": "page",
+      "type": "integer",
+      "required": false,
+      "description": "当前的页码"
+    },
+    {
+      "name": "per_page",
+      "type": "integer",
+      "required": false,
+      "description": "每页的数量，最大为 100，默认 20"
+    },
+    {
+      "name": "created_at",
+      "type": "string",
+      "required": false,
+      "description": "任务创建时间，例如：2024-11-20T13:00:21+08:00"
+    },
+    {
+      "name": "milestone",
+      "type": "string",
+      "required": false,
+      "description": "根据里程碑标题。none为没里程碑的"
+    },
+    {
+      "name": "assignee",
+      "type": "string",
+      "required": false,
+      "description": "Issue指派人ID"
+    },
+    {
+      "name": "creator",
+      "type": "string",
+      "required": false,
+      "description": "创建Issues的用户username"
+    },
+    {
+      "name": "created_after",
+      "type": "string",
+      "required": false,
+      "description": "返回在指定时间之后创建的问题，例如：2024-11-20T13:00:21+08:00"
+    },
+    {
+      "name": "created_before",
+      "type": "string",
+      "required": false,
+      "description": "返回在指定时间之前创建的问题，例如：2024-11-20T13:00:21+08:00"
+    },
+    {
+      "name": "updated_after",
+      "type": "string",
+      "required": false,
+      "description": "返回在指定时间之后更新的问题，例如：2024-11-20T13:00:21+08:00"
+    },
+    {
+      "name": "updated_before",
+      "type": "string",
+      "required": false,
+      "description": "返回在指定时间之前更新的问题，例如：2024-11-20T13:00:21+08:00"
+    },
+    {
+      "name": "search",
+      "type": "string",
+      "required": false,
+      "description": "通过关键字搜索issue标题或者内容"
+    }
+  ],
+  "requestBodyFields": [],
+  "responseFields": [
+    {
+      "name": "items[].id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].number",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].title",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].body",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].repository.id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].repository.full_name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].repository.path",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].repository.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].repository.description",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].repository.created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].repository.updated_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].repository.assigner",
+      "type": "object",
+      "description": ""
+    },
+    {
+      "name": "items[].repository.paas",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].updated_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].finished_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].labels[].id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].labels[].name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].labels[].color",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].labels[].created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].labels[].updated_at",
+      "type": "string",
+      "description": "label添加时间"
+    },
+    {
+      "name": "items[].issue_state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].comments",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].priority",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].issue_type",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].issue_state_detail.title",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].issue_state_detail.serial",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].issue_state_detail.id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].issue_type_detail.title",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].issue_type_detail.id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].issue_type_detail.is_system",
+      "type": "boolean",
+      "description": ""
+    },
+    {
+      "name": "items[].issue_priority_detail.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].issue_priority_detail.title",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].milestone.created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].milestone.description",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].milestone.due_on",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].milestone.number",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].milestone.repository_id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].milestone.state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].milestone.title",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].milestone.updated_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].milestone.url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].assignee.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].assignee.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].assignee.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].assignee.login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].assignee.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].visibility_reason",
+      "type": "string",
+      "description": "可见性，public：公开可见，confidential：私密，项目成员可见，other：其他原因导致的仅项目成员可见"
+    }
+  ],
+  "responseExample": {
+    "id": 152642,
+    "html_url": "https://test.gitcode.net/dengmengmian/test01/issues/15",
+    "number": "15",
+    "state": "opened",
+    "title": "半月据",
+    "body": "节油料被引系活力级少本化段维家住实。常气前步证时第样日所阶效温界到量。个导土机技亲布接增论始高世收圆流级集。此般区才听党机达两收文斗公加白。代军前分写第图美市与道及间。",
+    "user": {
+      "avatar_url": "https://gitcode-img.obs.cn-south-1.myhuaweicloud.com:443/fa/fe/f32a9fecc53e890afbd48fd098b0f6c5f20f062581400c76c85e5baab3f0d5b2.png",
+      "events_url": null,
+      "followers_url": null,
+      "following_url": null,
+      "gists_url": null,
+      "html_url": "https://test.gitcode.net/dengmengmian",
+      "id": "661ce4eab470b1430d456154",
+      "login": "dengmengmian",
+      "member_role": null,
+      "name": "麻凡_",
+      "organizations_url": null,
+      "received_events_url": null,
+      "remark": null,
+      "repos_url": null,
+      "starred_url": null,
+      "subscriptions_url": null,
+      "type": null,
+      "url": null
+    },
+    "assignee": {
+      "avatar_url": "https://gitcode-img.obs.cn-south-1.myhuaweicloud.com:443/fa/fe/f32a9fecc53e890afbd48fd098b0f6c5f20f062581400c76c85e5baab3f0d5b2.png",
+      "events_url": null,
+      "followers_url": null,
+      "following_url": null,
+      "gists_url": null,
+      "html_url": "https://test.gitcode.net/dengmengmian",
+      "id": "661ce4eab470b1430d456154",
+      "login": "dengmengmian",
+      "member_role": null,
+      "name": "麻凡_",
+      "organizations_url": null,
+      "received_events_url": null,
+      "remark": null,
+      "repos_url": null,
+      "starred_url": null,
+      "subscriptions_url": null,
+      "type": null,
+      "url": null
+    },
+    "repository": {
+      "id": 280713,
+      "full_name": "dengmengmian / test01",
+      "path": "test01",
+      "name": "test01",
+      "description": "",
+      "created_at": "2024-04-15T16:27:45.090+08:00",
+      "updated_at": "2024-04-15T16:27:45.090+08:00",
+      "assigner": null,
+      "pushed_at": null,
+      "paas": null,
+      "assignees_number": null,
+      "testers_number": null,
+      "assignee": null,
+      "testers": null
+    },
+    "created_at": "2024-04-18T14:35:15.479+08:00",
+    "updated_at": "2024-04-20T15:20:30.111+08:00",
+    "finished_at": null,
+    "labels": [
+      {
+        "id": 382379,
+        "name": "enim",
+        "color": "#428BCA"
+      },
+      {
+        "id": 382378,
+        "name": "proident",
+        "color": "#428BCA"
+      },
+      {
+        "id": 382377,
+        "name": "qui",
+        "color": "#428BCA"
+      }
+    ],
+    "priority": null,
+    "issue_type": null,
+    "issue_state": "opened",
+    "issue_state_detail": null
+  },
+  "curlExample": "curl -X GET \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/issues?access_token=YOUR_TOKEN\" \\\\\n  -H \"Accept: application/json\"",
+  "pythonExample": "import requests\n\nurl = \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/issues\"\nparams = {\"access_token\": \"YOUR_TOKEN\"}\nheaders = {\"Accept\": \"application/json\"}\ndata = {}\n\nresponse = requests.get(url, headers=headers, params=params, json=data)\nprint(response.json())",
+  "dataSource": "frontMatter.api",
+  "status": "done",
+  "notes": "requestBody omitted in source",
+  "metadata": {
+    "chunkUrl": "https://docs.gitcode.com/assets/js/45ed43b5.3662411b.js",
+    "sourceType": "openapi",
+    "titleFrom": "metadata.title"
+  }
+}

--- a/tests/fixtures/gitcode-api-contracts/raw/Issues/patch-api-v-5-repos-owner-issues-number.json
+++ b/tests/fixtures/gitcode-api-contracts/raw/Issues/patch-api-v-5-repos-owner-issues-number.json
@@ -1,0 +1,496 @@
+{
+  "category": "Issues",
+  "name": "更新Issue",
+  "slug": "patch-api-v-5-repos-owner-issues-number",
+  "docUrl": "https://docs.gitcode.com/docs/apis/patch-api-v-5-repos-owner-issues-number",
+  "summary": "",
+  "method": "PATCH",
+  "path": "/api/v5/repos/{owner}/issues/{number}",
+  "pathParams": [
+    {
+      "name": "owner",
+      "type": "string",
+      "required": true,
+      "description": "仓库所属空间地址(组织或个人的地址path)"
+    },
+    {
+      "name": "number",
+      "type": "string",
+      "required": true,
+      "description": "第几个 issue，即本仓库 issue 的序数"
+    }
+  ],
+  "queryParams": [
+    {
+      "name": "access_token",
+      "type": "string",
+      "required": true,
+      "description": "用户授权码"
+    }
+  ],
+  "requestBodyFields": [
+    {
+      "name": "repo",
+      "type": "string",
+      "required": true,
+      "description": "仓库路径"
+    },
+    {
+      "name": "title",
+      "type": "string",
+      "required": true,
+      "description": "Issue标题"
+    },
+    {
+      "name": "body",
+      "type": "string",
+      "required": false,
+      "description": "Issue描述"
+    },
+    {
+      "name": "state",
+      "type": "string",
+      "required": false,
+      "description": "Issue 状态，reopen（开启的）、close（关闭的）"
+    },
+    {
+      "name": "assignee",
+      "type": "string",
+      "required": false,
+      "description": "Issue负责人的username，多个用英文逗号隔开"
+    },
+    {
+      "name": "milestone",
+      "type": "integer",
+      "required": false,
+      "description": "里程碑序号"
+    },
+    {
+      "name": "labels",
+      "type": "string",
+      "required": false,
+      "description": "用逗号分开的标签，名称要求长度在 2-20 之间且非特殊字符。如: bug,performance"
+    },
+    {
+      "name": "security_hole",
+      "type": "string",
+      "required": false,
+      "description": "是否是私有issue(默认为false)"
+    },
+    {
+      "name": "status",
+      "type": "string",
+      "required": false,
+      "description": "issue状态（企业版支持）"
+    },
+    {
+      "name": "issue_severity",
+      "type": "string",
+      "required": true,
+      "description": "issue优先级（企业版支持）"
+    },
+    {
+      "name": "custom_fields[].field_name",
+      "type": "string",
+      "required": false,
+      "description": "字段名称"
+    },
+    {
+      "name": "custom_fields[].field_values[]",
+      "type": "array<string>",
+      "required": false,
+      "description": "字段的值数组"
+    }
+  ],
+  "responseFields": [
+    {
+      "name": "id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "number",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "title",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "body",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.events_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.followers_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.following_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.gists_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.member_role",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.organizations_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.received_events_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.remark",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.repos_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.starred_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.subscriptions_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.type",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "assignee.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "assignee.events_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "assignee.followers_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "assignee.following_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "assignee.gists_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "assignee.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "assignee.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "assignee.login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "assignee.member_role",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "assignee.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "assignee.organizations_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "assignee.received_events_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "assignee.remark",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "assignee.repos_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "assignee.starred_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "assignee.subscriptions_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "assignee.type",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "assignee.url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "repository.id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "repository.full_name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "repository.path",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "repository.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "repository.description",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "repository.created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "repository.updated_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "updated_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "finished_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "labels[].id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "labels[].name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "labels[].color",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "stage",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "severity",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "custom_fields[].field_name",
+      "type": "string",
+      "description": "自定义字段名称"
+    },
+    {
+      "name": "custom_fields[].field_type",
+      "type": "string",
+      "description": "自定义字段的类型。text_single：单行文本，text_multi：多行文本，integer：整数，decimal：小数，date：日期，select_single：单选下拉，select_multi：多选下拉，member_single：单选成员，member_multi：多选成员"
+    },
+    {
+      "name": "custom_fields[].field_visibility",
+      "type": "string",
+      "description": "可见性。0：仅管理员可见，1：所有人可见"
+    },
+    {
+      "name": "custom_fields[].field_values[]",
+      "type": "array<string>",
+      "description": "自定义字段的值"
+    }
+  ],
+  "responseExample": {
+    "id": 152467,
+    "html_url": "https://test.gitcode.net/dengmengmian/test01/issues/14",
+    "number": 14,
+    "state": "closed",
+    "title": "取属且阶",
+    "body": "速军间问备题意自系建技至速。那照与受证们老则使六么信。联不格决白转数特先到接单备心样本及。比论受感此中成要则片会受争里领周局。",
+    "user": {
+      "avatar_url": "https://gitcode-img.obs.cn-south-1.myhuaweicloud.com:443/fa/fe/f32a9fecc53e890afbd48fd098b0f6c5f20f062581400c76c85e5baab3f0d5b2.png",
+      "events_url": null,
+      "followers_url": null,
+      "following_url": null,
+      "gists_url": null,
+      "html_url": "https://test.gitcode.net/dengmengmian",
+      "id": "661ce4eab470b1430d456154",
+      "login": "dengmengmian",
+      "member_role": null,
+      "name": "麻凡_",
+      "organizations_url": null,
+      "received_events_url": null,
+      "remark": null,
+      "repos_url": null,
+      "starred_url": null,
+      "subscriptions_url": null,
+      "type": null,
+      "url": null
+    },
+    "assignee": {
+      "avatar_url": "https://gitcode-img.obs.cn-south-1.myhuaweicloud.com:443/fa/fe/f32a9fecc53e890afbd48fd098b0f6c5f20f062581400c76c85e5baab3f0d5b2.png",
+      "events_url": null,
+      "followers_url": null,
+      "following_url": null,
+      "gists_url": null,
+      "html_url": "https://test.gitcode.net/dengmengmian",
+      "id": "661ce4eab470b1430d456154",
+      "login": "dengmengmian",
+      "member_role": null,
+      "name": "麻凡_",
+      "organizations_url": null,
+      "received_events_url": null,
+      "remark": null,
+      "repos_url": null,
+      "starred_url": null,
+      "subscriptions_url": null,
+      "type": null,
+      "url": null
+    },
+    "repository": {
+      "id": 152467,
+      "full_name": "dengmengmian/test01",
+      "path": "test01",
+      "name": "test01",
+      "description": "",
+      "created_at": "2024-04-16T14:38:43.464+08:00",
+      "updated_at": "2024-04-18T18:27:21.955+08:00"
+    },
+    "created_at": "2024-04-16T14:38:43.464+08:00",
+    "updated_at": "2024-04-18T18:27:21.955+08:00",
+    "finished_at": "2024-04-16T14:49:45.166+08:00",
+    "labels": [
+      {
+        "id": 382389,
+        "name": "ad",
+        "color": "#428BCA"
+      },
+      {
+        "id": 382388,
+        "name": "id",
+        "color": "#428BCA"
+      }
+    ],
+    "stage": "New",
+    "severity": "Major"
+  },
+  "curlExample": "curl -X PATCH \"https://api.gitcode.com/api/v5/repos/owner_value/issues/number_value?access_token=YOUR_TOKEN\" \\\\\n  -H \"Accept: application/json\"\n  -H \"Content-Type: application/json\" \\\\\n  -d '{\n  \"repo\": \"value\"\n}'",
+  "pythonExample": "import requests\n\nurl = \"https://api.gitcode.com/api/v5/repos/owner_value/issues/number_value\"\nparams = {\"access_token\": \"YOUR_TOKEN\"}\nheaders = {\"Accept\": \"application/json\"}\ndata = {\n    \"repo\": \"value\"\n}\n\nresponse = requests.patch(url, headers=headers, params=params, json=data)\nprint(response.json())",
+  "dataSource": "frontMatter.api",
+  "status": "done",
+  "notes": "",
+  "metadata": {
+    "chunkUrl": "https://docs.gitcode.com/assets/js/064cfa13.b74021e7.js",
+    "sourceType": "openapi",
+    "titleFrom": "metadata.title"
+  }
+}

--- a/tests/fixtures/gitcode-api-contracts/raw/Issues/post-api-v-5-repos-owner-issues.json
+++ b/tests/fixtures/gitcode-api-contracts/raw/Issues/post-api-v-5-repos-owner-issues.json
@@ -1,0 +1,401 @@
+{
+  "category": "Issues",
+  "name": "创建Issue",
+  "slug": "post-api-v-5-repos-owner-issues",
+  "docUrl": "https://docs.gitcode.com/docs/apis/post-api-v-5-repos-owner-issues",
+  "summary": "",
+  "method": "POST",
+  "path": "/api/v5/repos/{owner}/issues",
+  "pathParams": [
+    {
+      "name": "owner",
+      "type": "string",
+      "required": true,
+      "description": "仓库所属空间地址(组织或个人的地址path)"
+    }
+  ],
+  "queryParams": [
+    {
+      "name": "access_token",
+      "type": "string",
+      "required": true,
+      "description": "用户授权码"
+    }
+  ],
+  "requestBodyFields": [
+    {
+      "name": "repo",
+      "type": "string",
+      "required": true,
+      "description": "仓库路径"
+    },
+    {
+      "name": "title",
+      "type": "string",
+      "required": true,
+      "description": "Issue标题"
+    },
+    {
+      "name": "body",
+      "type": "string",
+      "required": true,
+      "description": "Issue描述"
+    },
+    {
+      "name": "assignee",
+      "type": "string",
+      "required": false,
+      "description": "Issue负责人的username，多个用英文逗号隔开"
+    },
+    {
+      "name": "milestone",
+      "type": "integer",
+      "required": false,
+      "description": "里程碑序号"
+    },
+    {
+      "name": "labels",
+      "type": "string",
+      "required": false,
+      "description": "用逗号分开的标签，名称要求长度在 2-20 之间且非特殊字符。如: bug,performance"
+    },
+    {
+      "name": "security_hole",
+      "type": "string",
+      "required": false,
+      "description": "是否是私有issue(默认为false)"
+    },
+    {
+      "name": "template_path",
+      "type": "string",
+      "required": false,
+      "description": "issue模板路径，项目模板支持.gitcode，.github，.gitee目录下的文件，组织模板仅支持.gitcode项目下的.gitcode目录下的文件"
+    },
+    {
+      "name": "issue_type",
+      "type": "string",
+      "required": false,
+      "description": "issue类型（企业版支持），设置值需与企业issue高级功能中的设置保持一致"
+    },
+    {
+      "name": "issue_severity",
+      "type": "string",
+      "required": false,
+      "description": "issue优先级（企业版支持），设置值需与企业issue高级功能中的设置保持一致"
+    },
+    {
+      "name": "custom_fields[].field_name",
+      "type": "string",
+      "required": false,
+      "description": "字段名称"
+    },
+    {
+      "name": "custom_fields[].field_values[]",
+      "type": "array<string>",
+      "required": false,
+      "description": "字段的值数组"
+    }
+  ],
+  "responseFields": [
+    {
+      "name": "id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "number",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "title",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "body",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.events_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.followers_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.following_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.gists_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.member_role",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.organizations_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.received_events_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.remark",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.repos_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.starred_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.subscriptions_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.type",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "assignee",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "repository.id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "repository.full_name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "repository.path",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "repository.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "repository.description",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "repository.created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "repository.updated_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "updated_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "finished_at",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "labels[].id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "labels[].name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "labels[].color",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "labels[].created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "labels[].updated_at",
+      "type": "string",
+      "description": "label添加时间"
+    },
+    {
+      "name": "stage",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "severity",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "custom_fields[].field_name",
+      "type": "string",
+      "description": "自定义字段名称"
+    },
+    {
+      "name": "custom_fields[].field_type",
+      "type": "string",
+      "description": "自定义字段的类型。text_single：单行文本，text_multi：多行文本，integer：整数，decimal：小数，date：日期，select_single：单选下拉，select_multi：多选下拉，member_single：单选成员，member_multi：多选成员"
+    },
+    {
+      "name": "custom_fields[].field_visibility",
+      "type": "string",
+      "description": "可见性。0：仅管理员可见，1：所有人可见"
+    },
+    {
+      "name": "custom_fields[].field_values[]",
+      "type": "array<string>",
+      "description": "自定义字段的值"
+    }
+  ],
+  "responseExample": {
+    "id": 152642,
+    "html_url": "https://test.gitcode.net/dengmengmian/test01/issues/15",
+    "number": 15,
+    "state": "opened",
+    "title": "半月据",
+    "body": "节油料被引系活力级少本化段维家住实。常气前步证时第样日所阶效温界到量。个导土机技亲布接增论始高世收圆流级集。此般区才听党机达两收文斗公加白。代军前分写第图美市与道及间。",
+    "user": {
+      "avatar_url": "https://gitcode-img.obs.cn-south-1.myhuaweicloud.com:443/fa/fe/f32a9fecc53e890afbd48fd098b0f6c5f20f062581400c76c85e5baab3f0d5b2.png",
+      "events_url": null,
+      "followers_url": null,
+      "following_url": null,
+      "gists_url": null,
+      "html_url": "https://test.gitcode.net/dengmengmian",
+      "id": "661ce4eab470b1430d456154",
+      "login": "dengmengmian",
+      "member_role": null,
+      "name": "麻凡_",
+      "organizations_url": null,
+      "received_events_url": null,
+      "remark": null,
+      "repos_url": null,
+      "starred_url": null,
+      "subscriptions_url": null,
+      "type": null,
+      "url": null
+    },
+    "assignee": null,
+    "repository": {
+      "id": 152642,
+      "full_name": "dengmengmian/test01",
+      "path": "test01",
+      "name": "test01",
+      "description": "",
+      "created_at": "2024-04-18T14:35:15.479+08:00",
+      "updated_at": "2024-04-18T14:35:15.479+08:00"
+    },
+    "created_at": "2024-04-18T14:35:15.479+08:00",
+    "updated_at": "2024-04-18T14:35:15.479+08:00",
+    "finished_at": null,
+    "labels": [
+      {
+        "id": 382379,
+        "name": "enim",
+        "color": "#428BCA"
+      },
+      {
+        "id": 382378,
+        "name": "proident",
+        "color": "#428BCA"
+      },
+      {
+        "id": 382377,
+        "name": "qui",
+        "color": "#428BCA"
+      }
+    ],
+    "stage": "New",
+    "severity": "Major"
+  },
+  "curlExample": "curl -X POST \"https://api.gitcode.com/api/v5/repos/owner_value/issues?access_token=YOUR_TOKEN\" \\\\\n  -H \"Accept: application/json\"\n  -H \"Content-Type: application/json\" \\\\\n  -d '{\n  \"repo\": \"value\"\n}'",
+  "pythonExample": "import requests\n\nurl = \"https://api.gitcode.com/api/v5/repos/owner_value/issues\"\nparams = {\"access_token\": \"YOUR_TOKEN\"}\nheaders = {\"Accept\": \"application/json\"}\ndata = {\n    \"repo\": \"value\"\n}\n\nresponse = requests.post(url, headers=headers, params=params, json=data)\nprint(response.json())",
+  "dataSource": "frontMatter.api",
+  "status": "done",
+  "notes": "",
+  "metadata": {
+    "chunkUrl": "https://docs.gitcode.com/assets/js/4c80ea77.3ba45767.js",
+    "sourceType": "openapi",
+    "titleFrom": "metadata.title"
+  }
+}

--- a/tests/fixtures/gitcode-api-contracts/raw/Issues/post-api-v-5-repos-owner-repo-issues-number-comments.json
+++ b/tests/fixtures/gitcode-api-contracts/raw/Issues/post-api-v-5-repos-owner-repo-issues-number-comments.json
@@ -1,0 +1,215 @@
+{
+  "category": "Issues",
+  "name": "创建Issue评论",
+  "slug": "post-api-v-5-repos-owner-repo-issues-number-comments",
+  "docUrl": "https://docs.gitcode.com/docs/apis/post-api-v-5-repos-owner-repo-issues-number-comments",
+  "summary": "",
+  "method": "POST",
+  "path": "/api/v5/repos/{owner}/{repo}/issues/{number}/comments",
+  "pathParams": [
+    {
+      "name": "owner",
+      "type": "string",
+      "required": true,
+      "description": "仓库所属空间地址(组织或个人的地址path)"
+    },
+    {
+      "name": "repo",
+      "type": "string",
+      "required": true,
+      "description": "仓库路径(path)"
+    },
+    {
+      "name": "number",
+      "type": "string",
+      "required": true,
+      "description": "issue编号"
+    }
+  ],
+  "queryParams": [
+    {
+      "name": "access_token",
+      "type": "string",
+      "required": true,
+      "description": "用户授权码"
+    }
+  ],
+  "requestBodyFields": [
+    {
+      "name": "body",
+      "type": "string",
+      "required": true,
+      "description": "The contents of the comment."
+    }
+  ],
+  "responseFields": [
+    {
+      "name": "id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "body",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.events_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.followers_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.following_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.gists_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.member_role",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.organizations_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.received_events_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.remark",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.repos_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.starred_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.subscriptions_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.type",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user.url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target.issue.id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "target.issue.title",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target.issue.nubmer",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "created_at",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "updated_at",
+      "type": "null",
+      "description": ""
+    }
+  ],
+  "responseExample": {
+    "id": 271624,
+    "body": "评论内容。",
+    "user": {
+      "avatar_url": "https://gitcode-img.obs.cn-south-1.myhuaweicloud.com:443/fa/fe/f32a9fecc53e890afbd48fd098b0f6c5f20f062581400c76c85e5baab3f0d5b2.png",
+      "events_url": null,
+      "followers_url": null,
+      "following_url": null,
+      "gists_url": null,
+      "html_url": "https://test.gitcode.net/dengmengmian",
+      "id": "661ce4eab470b1430d456154",
+      "login": "dengmengmian",
+      "member_role": null,
+      "name": "麻凡_",
+      "organizations_url": null,
+      "received_events_url": null,
+      "remark": null,
+      "repos_url": null,
+      "starred_url": null,
+      "subscriptions_url": null,
+      "type": null,
+      "url": null
+    },
+    "target": {
+      "issue": {
+        "id": 152134,
+        "title": "",
+        "nubmer": 1
+      }
+    },
+    "created_at": null,
+    "updated_at": null
+  },
+  "curlExample": "curl -X POST \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/issues/number_value/comments?access_token=YOUR_TOKEN\" \\\\\n  -H \"Accept: application/json\"\n  -H \"Content-Type: application/json\" \\\\\n  -d '{\n  \"body\": \"value\"\n}'",
+  "pythonExample": "import requests\n\nurl = \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/issues/number_value/comments\"\nparams = {\"access_token\": \"YOUR_TOKEN\"}\nheaders = {\"Accept\": \"application/json\"}\ndata = {\n    \"body\": \"value\"\n}\n\nresponse = requests.post(url, headers=headers, params=params, json=data)\nprint(response.json())",
+  "dataSource": "frontMatter.api",
+  "status": "done",
+  "notes": "",
+  "metadata": {
+    "chunkUrl": "https://docs.gitcode.com/assets/js/49f2e34f.07bcc9a8.js",
+    "sourceType": "openapi",
+    "titleFrom": "metadata.title"
+  }
+}

--- a/tests/fixtures/gitcode-api-contracts/raw/Pull Requests/get-api-v-5-repos-owner-repo-pulls-number-comments.json
+++ b/tests/fixtures/gitcode-api-contracts/raw/Pull Requests/get-api-v-5-repos-owner-repo-pulls-number-comments.json
@@ -1,0 +1,217 @@
+{
+  "category": "Pull Requests",
+  "name": "获取某个Pull Request的所有评论",
+  "slug": "get-api-v-5-repos-owner-repo-pulls-number-comments",
+  "docUrl": "https://docs.gitcode.com/docs/apis/get-api-v-5-repos-owner-repo-pulls-number-comments",
+  "summary": "",
+  "method": "GET",
+  "path": "/api/v5/repos/{owner}/{repo}/pulls/{number}/comments",
+  "pathParams": [
+    {
+      "name": "owner",
+      "type": "string",
+      "required": true,
+      "description": "仓库所属空间地址(组织或个人的地址path)"
+    },
+    {
+      "name": "repo",
+      "type": "string",
+      "required": true,
+      "description": "仓库路径(path)"
+    },
+    {
+      "name": "number",
+      "type": "integer",
+      "required": true,
+      "description": "第几个PR，即本仓库PR的序数"
+    }
+  ],
+  "queryParams": [
+    {
+      "name": "access_token",
+      "type": "string",
+      "required": true,
+      "description": "用户授权码"
+    },
+    {
+      "name": "page",
+      "type": "integer",
+      "required": false,
+      "description": "当前的页码:默认为 1"
+    },
+    {
+      "name": "per_page",
+      "type": "integer",
+      "required": false,
+      "description": "每页的数量，最大为 100，默认 20"
+    },
+    {
+      "name": "direction",
+      "type": "string",
+      "required": false,
+      "description": "可选。升序/降序(asc/desc)"
+    },
+    {
+      "name": "comment_type",
+      "type": "string",
+      "required": false,
+      "description": "可选。筛选评论类型。代码行评论/pr普通评论:diff_comment/pr_comment"
+    }
+  ],
+  "requestBodyFields": [],
+  "responseFields": [
+    {
+      "name": "items[].id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].discussion_id",
+      "type": "string",
+      "description": "讨论id"
+    },
+    {
+      "name": "items[].body",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].updated_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].comment_type",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].resolved",
+      "type": "boolean",
+      "description": ""
+    },
+    {
+      "name": "items[].diff_file",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].diff_position.start_new_line",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].diff_position.end_new_line",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].diff_position.start_old_line",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].diff_position.end_old_line",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].reply[].id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].reply[].body",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].reply[].created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].reply[].updated_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].reply[].user.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].reply[].user.login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].reply[].user.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].reply[].user.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].reply[].user.html_url",
+      "type": "string",
+      "description": ""
+    }
+  ],
+  "responseExample": {
+    "id": "de772738e6dab92174c0e86c052ccf9bed24f747",
+    "body": "111",
+    "created_at": "2024-04-19T07:48:59.755+00:00",
+    "updated_at": "2024-04-19T07:48:59.755+00:00",
+    "user": {
+      "id": 708,
+      "login": "Lzm_0916",
+      "name": "Lzm_0916",
+      "avatar_url": "https://gitcode-img.obs.cn-south-1.myhuaweicloud.com:443/cb/da/6cb18d9ae9f1a94b4f640d3b848351c352c7869f33d0cb68e7acad4f224c4e23.png",
+      "html_url": "https://test.gitcode.net/Lzm_0916"
+    }
+  },
+  "curlExample": "curl -X GET \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/pulls/number_value/comments?access_token=YOUR_TOKEN\" \\\\\n  -H \"Accept: application/json\"",
+  "pythonExample": "import requests\n\nurl = \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/pulls/number_value/comments\"\nparams = {\"access_token\": \"YOUR_TOKEN\"}\nheaders = {\"Accept\": \"application/json\"}\ndata = {}\n\nresponse = requests.get(url, headers=headers, params=params, json=data)\nprint(response.json())",
+  "dataSource": "frontMatter.api",
+  "status": "done",
+  "notes": "requestBody omitted in source",
+  "metadata": {
+    "chunkUrl": "https://docs.gitcode.com/assets/js/f44c1bb6.21ffc5cd.js",
+    "sourceType": "openapi",
+    "titleFrom": "metadata.title"
+  }
+}

--- a/tests/fixtures/gitcode-api-contracts/raw/Pull Requests/get-api-v-5-repos-owner-repo-pulls-number.json
+++ b/tests/fixtures/gitcode-api-contracts/raw/Pull Requests/get-api-v-5-repos-owner-repo-pulls-number.json
@@ -1,0 +1,761 @@
+{
+  "category": "Pull Requests",
+  "name": "获取单个Pull Request",
+  "slug": "get-api-v-5-repos-owner-repo-pulls-number",
+  "docUrl": "https://docs.gitcode.com/docs/apis/get-api-v-5-repos-owner-repo-pulls-number",
+  "summary": "",
+  "method": "GET",
+  "path": "/api/v5/repos/{owner}/{repo}/pulls/{number}",
+  "pathParams": [
+    {
+      "name": "owner",
+      "type": "string",
+      "required": true,
+      "description": "仓库所属空间地址(组织或个人的地址path)"
+    },
+    {
+      "name": "repo",
+      "type": "string",
+      "required": true,
+      "description": "仓库路径(path)"
+    },
+    {
+      "name": "number",
+      "type": "integer",
+      "required": true,
+      "description": "第几个PR，即本仓库PR的序数"
+    }
+  ],
+  "queryParams": [
+    {
+      "name": "access_token",
+      "type": "string",
+      "required": true,
+      "description": "用户授权码"
+    }
+  ],
+  "requestBodyFields": [],
+  "responseFields": [
+    {
+      "name": "id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "number",
+      "type": "integer",
+      "description": "序号"
+    },
+    {
+      "name": "state",
+      "type": "string",
+      "description": "状态，open/closed/merged"
+    },
+    {
+      "name": "title",
+      "type": "string",
+      "description": "标题"
+    },
+    {
+      "name": "url",
+      "type": "string",
+      "description": "api url"
+    },
+    {
+      "name": "issue_url",
+      "type": "string",
+      "description": "关联的issue api url"
+    },
+    {
+      "name": "body",
+      "type": "string",
+      "description": "描述"
+    },
+    {
+      "name": "assignees_number",
+      "type": "integer",
+      "description": "审核人人数"
+    },
+    {
+      "name": "assignees[].id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "assignees[].login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "assignees[].name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "assignees[].avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "assignees[].html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "assignees[].assignee",
+      "type": "boolean",
+      "description": ""
+    },
+    {
+      "name": "assignees[].code_owner",
+      "type": "boolean",
+      "description": ""
+    },
+    {
+      "name": "assignees[].accept",
+      "type": "boolean",
+      "description": ""
+    },
+    {
+      "name": "testers[].id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "testers[].login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "testers[].name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "testers[].html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "testers[].assignee",
+      "type": "boolean",
+      "description": ""
+    },
+    {
+      "name": "testers[].code_owner",
+      "type": "boolean",
+      "description": ""
+    },
+    {
+      "name": "testers[].accept",
+      "type": "boolean",
+      "description": ""
+    },
+    {
+      "name": "approval_reviewers[].id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "approval_reviewers[].login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "approval_reviewers[].name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "approval_reviewers[].html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "approval_reviewers[].assignee",
+      "type": "boolean",
+      "description": ""
+    },
+    {
+      "name": "approval_reviewers[].code_owner",
+      "type": "boolean",
+      "description": ""
+    },
+    {
+      "name": "approval_reviewers[].accept",
+      "type": "boolean",
+      "description": ""
+    },
+    {
+      "name": "approval_reviewers[].avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "labels[].id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "labels[].color",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "labels[].name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "labels[].repository_id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "labels[].created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "labels[].updated_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "created_at",
+      "type": "string",
+      "description": "创建时间"
+    },
+    {
+      "name": "updated_at",
+      "type": "string",
+      "description": "更新时间"
+    },
+    {
+      "name": "closed_at",
+      "type": "string",
+      "description": "关闭时间"
+    },
+    {
+      "name": "merged_at",
+      "type": "string",
+      "description": "合并时间"
+    },
+    {
+      "name": "draft",
+      "type": "boolean",
+      "description": "是否为草稿"
+    },
+    {
+      "name": "can_merge_check",
+      "type": "boolean",
+      "description": "是否通过合并检查"
+    },
+    {
+      "name": "prune_branch",
+      "type": "boolean",
+      "description": "是否强制删除源分支"
+    },
+    {
+      "name": "mergeable",
+      "type": "boolean",
+      "description": "是否无冲突"
+    },
+    {
+      "name": "user.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "user.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "head.ref",
+      "type": "string",
+      "description": "分支路径"
+    },
+    {
+      "name": "head.sha",
+      "type": "string",
+      "description": "commit id"
+    },
+    {
+      "name": "head.label",
+      "type": "string",
+      "description": "label"
+    },
+    {
+      "name": "head.repo.path",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "head.repo.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "head.repo.namespace.path",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "head.repo.full_name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "head.repo.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "head.user.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "head.user.login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "head.user.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "head.user.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "head.user.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "base.ref",
+      "type": "string",
+      "description": "分支路径"
+    },
+    {
+      "name": "base.sha",
+      "type": "string",
+      "description": "commit id"
+    },
+    {
+      "name": "base.label",
+      "type": "string",
+      "description": "label"
+    },
+    {
+      "name": "base.repo.path",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "base.repo.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "base.repo.namespace.path",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "base.repo.full_name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "base.repo.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "mergeable_state.merge_request_id",
+      "type": "integer",
+      "description": "合并请求ID"
+    },
+    {
+      "name": "mergeable_state.state",
+      "type": "boolean",
+      "description": "状态"
+    },
+    {
+      "name": "mergeable_state.status_without_user_auth",
+      "type": "boolean",
+      "description": "无用户授权的状态"
+    },
+    {
+      "name": "mergeable_state.conflict_passed",
+      "type": "boolean",
+      "description": "冲突通过"
+    },
+    {
+      "name": "mergeable_state.branch_missing_passed",
+      "type": "boolean",
+      "description": "分支缺失通过"
+    },
+    {
+      "name": "mergeable_state.non_ff_passed",
+      "type": "boolean",
+      "description": "非快进通过"
+    },
+    {
+      "name": "mergeable_state.mr_state_passed",
+      "type": "boolean",
+      "description": "合并请求状态通过"
+    },
+    {
+      "name": "mergeable_state.merged_by_user_passed",
+      "type": "boolean",
+      "description": "用户合并通过"
+    },
+    {
+      "name": "mergeable_state.work_in_progress_passed",
+      "type": "boolean",
+      "description": "工作进展通过"
+    },
+    {
+      "name": "mergeable_state.resolve_discussion_passed",
+      "type": "boolean",
+      "description": "解决讨论通过"
+    },
+    {
+      "name": "mergeable_state.ci_state_passed",
+      "type": "boolean",
+      "description": "CI状态通过"
+    },
+    {
+      "name": "mergeable_state.merge_by_self_passed",
+      "type": "boolean",
+      "description": "自我合并通过"
+    },
+    {
+      "name": "mergeable_state.can_force_merge",
+      "type": "boolean",
+      "description": "可以强制合并"
+    },
+    {
+      "name": "mergeable_state.approval_reviewers_required_passed",
+      "type": "boolean",
+      "description": "代码评审是否通过"
+    },
+    {
+      "name": "mergeable_state.approval_approvers_required_passed",
+      "type": "boolean",
+      "description": "代码审查是否通过"
+    },
+    {
+      "name": "mergeable_state.approval_testers_required_passed",
+      "type": "boolean",
+      "description": "代码测试是否通过"
+    },
+    {
+      "name": "mergeable_state.merge_request_switch.review_mode",
+      "type": "string",
+      "description": "审查模式"
+    },
+    {
+      "name": "mergeable_state.merge_request_switch.merge_method",
+      "type": "string",
+      "description": "合并方法"
+    },
+    {
+      "name": "mergeable_state.merge_request_switch.only_allow_merge_if_all_discussions_are_resolved",
+      "type": "boolean",
+      "description": "只有在解决所有讨论后才允许合并"
+    },
+    {
+      "name": "mergeable_state.merge_request_switch.disable_merge_by_self",
+      "type": "boolean",
+      "description": "禁止自我合并"
+    },
+    {
+      "name": "mergeable_state.merge_request_switch.only_allow_merge_if_pipeline_succeeds",
+      "type": "boolean",
+      "description": "只有在管道成功后才允许合并"
+    },
+    {
+      "name": "mergeable_state.merge_request_switch.disable_squash_merge",
+      "type": "boolean",
+      "description": "禁止压缩合并"
+    },
+    {
+      "name": "mergeable_state.merge_request_switch.squash_merge_with_no_merge_commit",
+      "type": "boolean",
+      "description": "无合并提交的压缩合并"
+    },
+    {
+      "name": "mergeable_state.merge_request_switch.approval_required_reviewers_count",
+      "type": "integer",
+      "description": "需要审批的审查者数量"
+    },
+    {
+      "name": "mergeable_state.merge_request_switch.approval_required_reviewers_branch",
+      "type": "string",
+      "description": "需要审批的审查者分支"
+    },
+    {
+      "name": "mergeable_state.merge_request_switch.add_notes_after_merged",
+      "type": "boolean",
+      "description": "合并后添加注释"
+    },
+    {
+      "name": "mergeable_state.merge_request_switch.mark_auto_merged_mr_as_closed",
+      "type": "boolean",
+      "description": "将自动合并的MR标记为已关闭"
+    },
+    {
+      "name": "mergeable_state.merge_request_switch.can_force_merge",
+      "type": "boolean",
+      "description": "可以强制合并"
+    },
+    {
+      "name": "mergeable_state.merge_request_switch.can_reopen",
+      "type": "boolean",
+      "description": "可以重新开放"
+    },
+    {
+      "name": "mergeable_state.reason",
+      "type": "object",
+      "description": "原因"
+    },
+    {
+      "name": "mergeable_state.check_tasks_num",
+      "type": "integer",
+      "description": "检查事项总数"
+    },
+    {
+      "name": "mergeable_state.all_depend_merge_request_merged_passed",
+      "type": "boolean",
+      "description": "所有依赖合并请求已合并通过"
+    },
+    {
+      "name": "mergeable_state.approval_approvers_result",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "mergeable_state.approval_testers_result",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "milestone.created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "milestone.description",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "milestone.number",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "milestone.state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "milestone.title",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "milestone.updated_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "visibility_reason",
+      "type": "string",
+      "description": "可见性，public：公开可见，other：仅项目成员可见"
+    },
+    {
+      "name": "merged_by.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "merged_by.login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "merged_by.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "merged_by.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "merged_by.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "close_related_issue",
+      "type": "boolean",
+      "description": "合并时是否关闭关联的issue"
+    }
+  ],
+  "responseExample": {
+    "id": 111,
+    "html_url": "http://gitcode.com/sytest/paopao/pull/1",
+    "number": 1,
+    "url": "https://api.gitcode.com/api/v5/repos/sytest/paopao/pulls/1",
+    "issue_url": "https://api.gitcode.com/api/v5/repos/sytest/paopao/pulls/1/issues",
+    "state": "open",
+    "assignees_number": 1,
+    "assignees": [
+      {
+        "id": 2,
+        "login": "test",
+        "name": "test_web",
+        "avatar_url": "http://gitcode.com/sytest/paopao/pull/1.png",
+        "html_url": "http://gitcode.com/sytest/paopao/pull/1",
+        "assigness": true,
+        "code_owner": false,
+        "accept": true
+      }
+    ],
+    "testers": [
+      {
+        "id": 2,
+        "login": "test",
+        "name": "test_web",
+        "avatar_url": "http://gitcode.com/sytest/paopao/pull/1.png",
+        "html_url": "http://gitcode.com/sytest/paopao/pull/1",
+        "assigness": true,
+        "code_owner": false,
+        "accept": true
+      }
+    ],
+    "labels": [
+      {
+        "id": 222,
+        "name": "label1",
+        "repository_id": 1,
+        "created_at": "",
+        "updated_at": ""
+      }
+    ],
+    "created_at": "",
+    "updated_at": "",
+    "closed__at": "",
+    "draft": false,
+    "merged_at": "",
+    "can_merge_check": false,
+    "mergeable": true,
+    "body": "Description",
+    "user": {
+      "id": "userId",
+      "login": "test"
+    },
+    "head": {
+      "label": "test",
+      "ref": "test",
+      "sha": "91861a9668041fc1c0ff51d1db66b6297179f5e6",
+      "repo": {
+        "path": "paopao",
+        "name": "paopao"
+      }
+    },
+    "base": {
+      "label": "main",
+      "ref": "main",
+      "sha": "91861a9668041fc1c0ff51d1db66b6297179f5e6",
+      "repo": {
+        "path": "paopao",
+        "name": "paopao"
+      }
+    },
+    "prune_branch": false,
+    "mergeable_state": {
+      "merge_request_id": 111,
+      "state": false,
+      "status_without_user_auth": false,
+      "conflict_passed": false,
+      "branch_missing_passed": true,
+      "non_ff_passed": true,
+      "mr_state_passed": true,
+      "merged_by_user_passed": true,
+      "work_in_progress_passed": true,
+      "resolve_discussion_passed": true,
+      "ci_state_passed": true,
+      "merge_by_self_passed": true,
+      "can_force_merge": false,
+      "approval_reviewers_required_passed": true,
+      "approval_approvers_required_passed": true,
+      "approval_testers_required_passed": true,
+      "merge_request_switch": {
+        "review_mode": "approval",
+        "merge_method": "merge",
+        "only_allow_merge_if_all_discussions_are_resolved": false,
+        "disable_merge_by_self": false,
+        "only_allow_merge_if_pipeline_succeeds": false,
+        "disable_squash_merge": false,
+        "squash_merge_with_no_merge_commit": false,
+        "approval_required_reviewers_count": 0,
+        "approval_required_reviewers_branch": "*",
+        "add_notes_after_merged": false,
+        "mark_auto_merged_mr_as_closed": false,
+        "can_force_merge": false,
+        "can_reopen": true
+      },
+      "reason": {},
+      "check_tasks_num": 0
+    },
+    "ref_pull_requests": [
+      {
+        "id": 191973,
+        "number": 3,
+        "state": "merged",
+        "title": "dddd"
+      }
+    ]
+  },
+  "curlExample": "curl -X GET \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/pulls/number_value?access_token=YOUR_TOKEN\" \\\\\n  -H \"Accept: application/json\"",
+  "pythonExample": "import requests\n\nurl = \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/pulls/number_value\"\nparams = {\"access_token\": \"YOUR_TOKEN\"}\nheaders = {\"Accept\": \"application/json\"}\ndata = {}\n\nresponse = requests.get(url, headers=headers, params=params, json=data)\nprint(response.json())",
+  "dataSource": "frontMatter.api",
+  "status": "done",
+  "notes": "requestBody omitted in source",
+  "metadata": {
+    "chunkUrl": "https://docs.gitcode.com/assets/js/423ea94d.ef071756.js",
+    "sourceType": "openapi",
+    "titleFrom": "metadata.title"
+  }
+}

--- a/tests/fixtures/gitcode-api-contracts/raw/Pull Requests/get-api-v-5-repos-owner-repo-pulls.json
+++ b/tests/fixtures/gitcode-api-contracts/raw/Pull Requests/get-api-v-5-repos-owner-repo-pulls.json
@@ -1,0 +1,875 @@
+{
+  "category": "Pull Requests",
+  "name": "获取项目Pull Request列表",
+  "slug": "get-api-v-5-repos-owner-repo-pulls",
+  "docUrl": "https://docs.gitcode.com/docs/apis/get-api-v-5-repos-owner-repo-pulls",
+  "summary": "",
+  "method": "GET",
+  "path": "/api/v5/repos/{owner}/{repo}/pulls",
+  "pathParams": [
+    {
+      "name": "owner",
+      "type": "string",
+      "required": true,
+      "description": "仓库所属空间地址(组织或个人的地址path)"
+    },
+    {
+      "name": "repo",
+      "type": "string",
+      "required": true,
+      "description": "仓库路径(path)"
+    }
+  ],
+  "queryParams": [
+    {
+      "name": "access_token",
+      "type": "string",
+      "required": true,
+      "description": "用户授权码"
+    },
+    {
+      "name": "state",
+      "type": "string",
+      "required": false,
+      "description": "可选。Pull Request状态: all、open、closed、locked、merged，默认：all"
+    },
+    {
+      "name": "base",
+      "type": "string",
+      "required": false,
+      "description": "可选。Pull Request提交目标分支的名称"
+    },
+    {
+      "name": "since",
+      "type": "string",
+      "required": false,
+      "description": "可选。起始的更新时间，要求时间格式为 ISO 8601 例如：`2024-11-20T13:00:21+08:00`"
+    },
+    {
+      "name": "direction",
+      "type": "string",
+      "required": false,
+      "description": "可选。升序/降序 默认：desc(asc 或者 desc)"
+    },
+    {
+      "name": "sort",
+      "type": "string",
+      "required": false,
+      "description": "可选。排序字段: created、updated 默认：created"
+    },
+    {
+      "name": "milestone_number",
+      "type": "integer",
+      "required": false,
+      "description": "可选。里程碑序号(id)"
+    },
+    {
+      "name": "labels",
+      "type": "string",
+      "required": false,
+      "description": "以逗号分隔的标签名称列表"
+    },
+    {
+      "name": "page",
+      "type": "integer",
+      "required": false,
+      "description": "当前的页码:默认为 1"
+    },
+    {
+      "name": "per_page",
+      "type": "integer",
+      "required": false,
+      "description": "每页的数量，最大为 100，默认 20"
+    },
+    {
+      "name": "author",
+      "type": "string",
+      "required": false,
+      "description": "可选。PR 创建者用户名"
+    },
+    {
+      "name": "assignee",
+      "type": "string",
+      "required": false,
+      "description": "可选。PR 负责人用户名"
+    },
+    {
+      "name": "reviewer",
+      "type": "string",
+      "required": false,
+      "description": "可选。PR 评审人用户名"
+    },
+    {
+      "name": "merged_after",
+      "type": "string",
+      "required": false,
+      "description": "返回在指定时间之后合并的合并请求,要求时间格式为 ISO 8601 例如：`2024-11-20T13:00:21+08:00`"
+    },
+    {
+      "name": "merged_before",
+      "type": "string",
+      "required": false,
+      "description": "返回在指定时间之前合并的合并请求,要求时间格式为 ISO 8601 例如：`2024-11-20T13:00:21+08:00`"
+    },
+    {
+      "name": "only_count",
+      "type": "boolean",
+      "required": false,
+      "description": "如果为true，则仅返回合并请求的计数，默认为 false"
+    },
+    {
+      "name": "created_after",
+      "type": "string",
+      "required": false,
+      "description": "返回在指定时间之后创建的合并请求,要求时间格式为 ISO 8601 例如：`2024-11-20T13:00:21+08:00`"
+    },
+    {
+      "name": "created_before",
+      "type": "string",
+      "required": false,
+      "description": "返回在指定时间之前创建的合并请求,要求时间格式为 ISO 8601 例如：`2024-11-20T13:00:21+08:00`"
+    },
+    {
+      "name": "updated_before",
+      "type": "string",
+      "required": false,
+      "description": "返回在指定时间之前更新的合并请求,要求时间格式为 ISO 8601 例如：`2024-11-20T13:00:21+08:00`"
+    },
+    {
+      "name": "updated_after",
+      "type": "string",
+      "required": false,
+      "description": "返回在指定时间之后更新的合并请求,要求时间格式为 ISO 8601 例如：`2024-11-20T13:00:21+08:00`"
+    }
+  ],
+  "requestBodyFields": [],
+  "responseFields": [
+    {
+      "name": "items[].number",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].close_related_issue",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].prune_branch",
+      "type": "boolean",
+      "description": ""
+    },
+    {
+      "name": "items[].draft",
+      "type": "boolean",
+      "description": ""
+    },
+    {
+      "name": "items[].labels[].id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].labels[].name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].labels[].color",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].labels[].created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].labels[].updated_at",
+      "type": "string",
+      "description": "label添加时间"
+    },
+    {
+      "name": "items[].user.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.user_id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.object_id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.email",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.name_cn",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].user.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].assignees[]",
+      "type": "array<string>",
+      "description": ""
+    },
+    {
+      "name": "items[].testers[]",
+      "type": "array<string>",
+      "description": ""
+    },
+    {
+      "name": "items[].head.label",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.ref",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.sha",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.user.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.user.login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.user.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.user.state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.user.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.user.email",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.user.name_cn",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.user.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.full_path",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.full_name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.human_name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.path",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.description",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.owner.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.owner.login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.owner.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.owner.state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.owner.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.owner.email",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.owner.name_cn",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.owner.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.assigner.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.assigner.login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.assigner.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.assigner.state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.assigner.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.assigner.email",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.assigner.name_cn",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.assigner.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.internal",
+      "type": "boolean",
+      "description": ""
+    },
+    {
+      "name": "items[].head.repo.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.label",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.ref",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.sha",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.user.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.user.login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.user.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.user.state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.user.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.user.email",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.user.name_cn",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.user.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.full_path",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.full_name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.human_name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.path",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.description",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.owner.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.owner.login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.owner.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.owner.state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.owner.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.owner.email",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.owner.name_cn",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.owner.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.assigner.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.assigner.login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.assigner.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.assigner.state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.assigner.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.assigner.email",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.assigner.name_cn",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.assigner.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.internal",
+      "type": "boolean",
+      "description": ""
+    },
+    {
+      "name": "items[].base.repo.html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].iid",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].project_id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].title",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].body",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].assignees_number",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].testers_number",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].updated_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].merged_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].closed_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].target_branch",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].source_branch",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].source_project_id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].force_remove_source_branch",
+      "type": "boolean",
+      "description": ""
+    },
+    {
+      "name": "items[].web_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].merge_request_type",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].review_mode",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].added_lines",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].removed_lines",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].diff_refs.base_sha",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].diff_refs.head_sha",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].diff_refs.start_sha",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].notes",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].pipeline_status",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].pipeline_status_with_code_quality",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].source_git_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].can_merge_check",
+      "type": "boolean",
+      "description": ""
+    },
+    {
+      "name": "items[].mergeable",
+      "type": "boolean",
+      "description": ""
+    },
+    {
+      "name": "items[].locked",
+      "type": "boolean",
+      "description": ""
+    },
+    {
+      "name": "items[].closed_by.id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "items[].closed_by.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].closed_by.username",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].closed_by.iam_id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].closed_by.nick_name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].closed_by.state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].closed_by.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].closed_by.email",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].closed_by.name_cn",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].closed_by.web_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].visibility_reason",
+      "type": "string",
+      "description": "可见性，public：公开可见，other：仅项目成员可见"
+    },
+    {
+      "name": "items[].merged_by.id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].merged_by.login",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].merged_by.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].merged_by.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "items[].merged_by.html_url",
+      "type": "string",
+      "description": ""
+    }
+  ],
+  "responseExample": {
+    "all": 1,
+    "opened": 1,
+    "closed": 0,
+    "merged": 0,
+    "locked": 0
+  },
+  "curlExample": "curl -X GET \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/pulls?access_token=YOUR_TOKEN\" \\\\\n  -H \"Accept: application/json\"",
+  "pythonExample": "import requests\n\nurl = \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/pulls\"\nparams = {\"access_token\": \"YOUR_TOKEN\"}\nheaders = {\"Accept\": \"application/json\"}\ndata = {}\n\nresponse = requests.get(url, headers=headers, params=params, json=data)\nprint(response.json())",
+  "dataSource": "frontMatter.api",
+  "status": "done",
+  "notes": "requestBody omitted in source",
+  "metadata": {
+    "chunkUrl": "https://docs.gitcode.com/assets/js/f6a19c81.88ac356a.js",
+    "sourceType": "openapi",
+    "titleFrom": "metadata.title"
+  }
+}

--- a/tests/fixtures/gitcode-api-contracts/raw/Pull Requests/patch-api-v-5-repos-owner-repo-pulls-number.json
+++ b/tests/fixtures/gitcode-api-contracts/raw/Pull Requests/patch-api-v-5-repos-owner-repo-pulls-number.json
@@ -1,0 +1,125 @@
+{
+  "category": "Pull Requests",
+  "name": "更新Pull Request信息",
+  "slug": "patch-api-v-5-repos-owner-repo-pulls-number",
+  "docUrl": "https://docs.gitcode.com/docs/apis/patch-api-v-5-repos-owner-repo-pulls-number",
+  "summary": "",
+  "method": "PATCH",
+  "path": "/api/v5/repos/{owner}/{repo}/pulls/{number}",
+  "pathParams": [
+    {
+      "name": "owner",
+      "type": "string",
+      "required": true,
+      "description": "仓库所属空间地址(组织或个人的地址path)"
+    },
+    {
+      "name": "repo",
+      "type": "string",
+      "required": true,
+      "description": "仓库路径(path)"
+    },
+    {
+      "name": "number",
+      "type": "integer",
+      "required": true,
+      "description": "第几个PR，即本仓库PR的序数"
+    }
+  ],
+  "queryParams": [
+    {
+      "name": "access_token",
+      "type": "string",
+      "required": true,
+      "description": "用户授权码"
+    }
+  ],
+  "requestBodyFields": [
+    {
+      "name": "title",
+      "type": "string",
+      "required": false,
+      "description": "可选。Pull Request标题"
+    },
+    {
+      "name": "body",
+      "type": "string",
+      "required": false,
+      "description": "可选。Pull Request内容"
+    },
+    {
+      "name": "state",
+      "type": "string",
+      "required": false,
+      "description": "可选。Pull Request状态"
+    },
+    {
+      "name": "milestone_number",
+      "type": "integer",
+      "required": false,
+      "description": "可选。里程碑序号(id)"
+    },
+    {
+      "name": "labels",
+      "type": "string",
+      "required": false,
+      "description": "用逗号分开的标签，名称要求长度在 2-20 之间且非特殊字符。如: bug,performance"
+    },
+    {
+      "name": "draft",
+      "type": "boolean",
+      "required": false,
+      "description": "是否设置为草稿"
+    },
+    {
+      "name": "close_related_issue",
+      "type": "boolean",
+      "required": false,
+      "description": "可选，合并后是否关闭关联的 Issue，默认根据仓库配置设置"
+    }
+  ],
+  "responseFields": [
+    {
+      "name": "title",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "body",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "updated_at",
+      "type": "string",
+      "description": ""
+    }
+  ],
+  "responseExample": {
+    "title": "test_b3->dev",
+    "body": "new: 新增文件 test_b3 \n2223333444444",
+    "state": "opened",
+    "created_at": "2024-03-28T22:23:29.999+08:00",
+    "updated_at": "2024-04-14T21:06:52.499+08:00"
+  },
+  "curlExample": "curl -X PATCH \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/pulls/number_value?access_token=YOUR_TOKEN\" \\\\\n  -H \"Accept: application/json\"\n  -H \"Content-Type: application/json\" \\\\\n  -d '{\n  \"title\": \"value\"\n}'",
+  "pythonExample": "import requests\n\nurl = \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/pulls/number_value\"\nparams = {\"access_token\": \"YOUR_TOKEN\"}\nheaders = {\"Accept\": \"application/json\"}\ndata = {\n    \"title\": \"value\"\n}\n\nresponse = requests.patch(url, headers=headers, params=params, json=data)\nprint(response.json())",
+  "dataSource": "frontMatter.api",
+  "status": "done",
+  "notes": "",
+  "metadata": {
+    "chunkUrl": "https://docs.gitcode.com/assets/js/240860d2.82838c2f.js",
+    "sourceType": "openapi",
+    "titleFrom": "metadata.title"
+  }
+}

--- a/tests/fixtures/gitcode-api-contracts/raw/Pull Requests/post-api-v-5-repos-owner-repo-pulls-number-comments.json
+++ b/tests/fixtures/gitcode-api-contracts/raw/Pull Requests/post-api-v-5-repos-owner-repo-pulls-number-comments.json
@@ -1,0 +1,83 @@
+{
+  "category": "Pull Requests",
+  "name": "提交pull request 评论",
+  "slug": "post-api-v-5-repos-owner-repo-pulls-number-comments",
+  "docUrl": "https://docs.gitcode.com/docs/apis/post-api-v-5-repos-owner-repo-pulls-number-comments",
+  "summary": "",
+  "method": "POST",
+  "path": "/api/v5/repos/{owner}/{repo}/pulls/{number}/comments",
+  "pathParams": [
+    {
+      "name": "owner",
+      "type": "string",
+      "required": true,
+      "description": "仓库所属空间地址(组织或个人的地址path)"
+    },
+    {
+      "name": "repo",
+      "type": "string",
+      "required": true,
+      "description": "仓库路径(path)"
+    },
+    {
+      "name": "number",
+      "type": "integer",
+      "required": true,
+      "description": "第几个PR，即本仓库PR的序数"
+    }
+  ],
+  "queryParams": [
+    {
+      "name": "access_token",
+      "type": "string",
+      "required": true,
+      "description": "用户授权码"
+    }
+  ],
+  "requestBodyFields": [
+    {
+      "name": "body",
+      "type": "string",
+      "required": true,
+      "description": "评论内容"
+    },
+    {
+      "name": "path",
+      "type": "string",
+      "required": false,
+      "description": "文件的相对路径"
+    },
+    {
+      "name": "position",
+      "type": "integer",
+      "required": false,
+      "description": "代码所在行数"
+    }
+  ],
+  "responseFields": [
+    {
+      "name": "id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "body",
+      "type": "string",
+      "description": ""
+    }
+  ],
+  "responseExample": {
+    "id": "97219c08d421e55cfa841deca16a30f5d7269e10",
+    "body": "22222"
+  },
+  "curlExample": "curl -X POST \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/pulls/number_value/comments?access_token=YOUR_TOKEN\" \\\\\n  -H \"Accept: application/json\"\n  -H \"Content-Type: application/json\" \\\\\n  -d '{\n  \"body\": \"value\"\n}'",
+  "pythonExample": "import requests\n\nurl = \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/pulls/number_value/comments\"\nparams = {\"access_token\": \"YOUR_TOKEN\"}\nheaders = {\"Accept\": \"application/json\"}\ndata = {\n    \"body\": \"value\"\n}\n\nresponse = requests.post(url, headers=headers, params=params, json=data)\nprint(response.json())",
+  "dataSource": "frontMatter.api",
+  "status": "done",
+  "notes": "",
+  "metadata": {
+    "chunkUrl": "https://docs.gitcode.com/assets/js/3a244d2b.2aecd5e6.js",
+    "sourceType": "openapi",
+    "titleFrom": "metadata.title"
+  }
+}

--- a/tests/fixtures/gitcode-api-contracts/raw/Pull Requests/post-api-v-5-repos-owner-repo-pulls-number-review.json
+++ b/tests/fixtures/gitcode-api-contracts/raw/Pull Requests/post-api-v-5-repos-owner-repo-pulls-number-review.json
@@ -1,0 +1,57 @@
+{
+  "category": "Pull Requests",
+  "name": "处理 Pull Request审查",
+  "slug": "post-api-v-5-repos-owner-repo-pulls-number-review",
+  "docUrl": "https://docs.gitcode.com/docs/apis/post-api-v-5-repos-owner-repo-pulls-number-review",
+  "summary": "",
+  "method": "POST",
+  "path": "/api/v5/repos/{owner}/{repo}/pulls/{number}/review",
+  "pathParams": [
+    {
+      "name": "owner",
+      "type": "string",
+      "required": true,
+      "description": "仓库所属空间地址(组织或个人的地址path)"
+    },
+    {
+      "name": "repo",
+      "type": "string",
+      "required": true,
+      "description": "仓库路径(path)"
+    },
+    {
+      "name": "number",
+      "type": "integer",
+      "required": true,
+      "description": "第几个PR，即本仓库PR的序数"
+    }
+  ],
+  "queryParams": [
+    {
+      "name": "access_token",
+      "type": "string",
+      "required": true,
+      "description": "用户授权码"
+    }
+  ],
+  "requestBodyFields": [
+    {
+      "name": "force",
+      "type": "boolean",
+      "required": false,
+      "description": "是否强制测试通过（默认否），只对管理员生效"
+    }
+  ],
+  "responseFields": [],
+  "responseExample": {},
+  "curlExample": "curl -X POST \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/pulls/number_value/review?access_token=YOUR_TOKEN\" \\\\\n  -H \"Accept: application/json\"\n  -H \"Content-Type: application/json\" \\\\\n  -d '{\n  \"force\": true\n}'",
+  "pythonExample": "import requests\n\nurl = \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/pulls/number_value/review\"\nparams = {\"access_token\": \"YOUR_TOKEN\"}\nheaders = {\"Accept\": \"application/json\"}\ndata = {\n    \"force\": true\n}\n\nresponse = requests.post(url, headers=headers, params=params, json=data)\nprint(response.json())",
+  "dataSource": "frontMatter.api",
+  "status": "done",
+  "notes": "responseFields omitted in source",
+  "metadata": {
+    "chunkUrl": "https://docs.gitcode.com/assets/js/346dab88.5d05b628.js",
+    "sourceType": "openapi",
+    "titleFrom": "metadata.title"
+  }
+}

--- a/tests/fixtures/gitcode-api-contracts/raw/Pull Requests/post-api-v-5-repos-owner-repo-pulls.json
+++ b/tests/fixtures/gitcode-api-contracts/raw/Pull Requests/post-api-v-5-repos-owner-repo-pulls.json
@@ -1,0 +1,2082 @@
+{
+  "category": "Pull Requests",
+  "name": "创建Pull Request",
+  "slug": "post-api-v-5-repos-owner-repo-pulls",
+  "docUrl": "https://docs.gitcode.com/docs/apis/post-api-v-5-repos-owner-repo-pulls",
+  "summary": "",
+  "method": "POST",
+  "path": "/api/v5/repos/{owner}/{repo}/pulls",
+  "pathParams": [
+    {
+      "name": "owner",
+      "type": "string",
+      "required": true,
+      "description": "仓库所属空间地址(组织或个人的地址path)"
+    },
+    {
+      "name": "repo",
+      "type": "string",
+      "required": true,
+      "description": "仓库路径(path)"
+    }
+  ],
+  "queryParams": [
+    {
+      "name": "access_token",
+      "type": "string",
+      "required": true,
+      "description": "用户授权码"
+    }
+  ],
+  "requestBodyFields": [
+    {
+      "name": "title",
+      "type": "string",
+      "required": true,
+      "description": "必填。Pull Request标题"
+    },
+    {
+      "name": "head",
+      "type": "string",
+      "required": true,
+      "description": "必填。Pull Request提交的源分支。格式：branch 如果跨仓PR传：username:branch"
+    },
+    {
+      "name": "base",
+      "type": "string",
+      "required": true,
+      "description": "必填。Pull Request提交目标分支的名称"
+    },
+    {
+      "name": "body",
+      "type": "string",
+      "required": false,
+      "description": "可选。Pull Request内容"
+    },
+    {
+      "name": "milestone_number",
+      "type": "integer",
+      "required": false,
+      "description": "可选。里程碑序号(id)"
+    },
+    {
+      "name": "labels",
+      "type": "string",
+      "required": false,
+      "description": "用逗号分开的标签，名称要求长度在 2-20 之间且非特殊字符。如: bug,performance"
+    },
+    {
+      "name": "issue",
+      "type": "string",
+      "required": false,
+      "description": "可选。Pull Request的标题和内容可以根据指定的Issue Id自动填充"
+    },
+    {
+      "name": "assignees",
+      "type": "string",
+      "required": false,
+      "description": "可选。审查人员username，可多个，半角逗号分隔，如：(username1,username2), 注意: 当仓库代码审查设置中已设置【指派审查人员】则此选项无效"
+    },
+    {
+      "name": "testers",
+      "type": "string",
+      "required": false,
+      "description": "可选。测试人员username，可多个，半角逗号分隔，如：(username1,username2), 注意: 当仓库代码审查设置中已设置【指派测试人员】则此选项无效"
+    },
+    {
+      "name": "prune_source_branch",
+      "type": "boolean",
+      "required": false,
+      "description": "可选。合并PR后是否删除源分支，默认false（不删除）"
+    },
+    {
+      "name": "draft",
+      "type": "boolean",
+      "required": false,
+      "description": "是否设置为草稿 默认false"
+    },
+    {
+      "name": "squash",
+      "type": "boolean",
+      "required": false,
+      "description": "接受 Pull Request时使用扁平化（Squash）合并, 默认false"
+    },
+    {
+      "name": "squash_commit_message",
+      "type": "string",
+      "required": false,
+      "description": "squash提交信息"
+    },
+    {
+      "name": "fork_path",
+      "type": "string",
+      "required": false,
+      "description": "fork项目路径【owner/repo】，跨仓PR 必填。"
+    },
+    {
+      "name": "close_related_issue",
+      "type": "boolean",
+      "required": false,
+      "description": "可选，合并后是否关闭关联的 Issue，默认根据仓库配置设置"
+    }
+  ],
+  "responseFields": [
+    {
+      "name": "id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "html_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "diff_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "patch_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "issue_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "commits_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "review_comments_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "review_comment_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "comments_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "number",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "title",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "description",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "updated_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "merged_by",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "merged_at",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "closed_by",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "closed_at",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "title_html",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "description_html",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_branch",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_branch",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "squash_commit_message",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "user_notes_count",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "upvotes",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "downvotes",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "author.id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "author.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "author.username",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "author.iam_id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "author.nick_name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "author.state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "author.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "author.avatar_path",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "author.email",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "author.name_cn",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "author.web_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "author.tenant_name",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "author.is_member",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "assignee",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project_id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "target_project_id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "labels[].id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "labels[].name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "labels[].color",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "labels[].created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "labels[].updated_at",
+      "type": "string",
+      "description": "label添加时间"
+    },
+    {
+      "name": "work_in_progress",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "milestone",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "merge_when_pipeline_succeeds",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "merge_status",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "sha",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "merge_commit_sha",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "discussion_locked",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "should_remove_source_branch",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "force_remove_source_branch",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "allow_collaboration",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "allow_maintainer_to_push",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "web_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "time_stats.time_estimate",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "time_stats.total_time_spent",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "time_stats.human_time_estimate",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "time_stats.human_total_time_spent",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "squash",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "merge_request_type",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "has_pre_merge_ref",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "review_mode",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "is_source_branch_exist",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_reviewers[].id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_reviewers[].username",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_reviewers[].name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_reviewers[].nick_name",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_reviewers[].name_cn",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_reviewers[].email",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_reviewers[].state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_reviewers[].is_codeowner",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_reviewers[].updated_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_reviewers[].avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_approvers[].id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_approvers[].username",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_approvers[].name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_approvers[].nick_name",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_approvers[].name_cn",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_approvers[].email",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_approvers[].state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_approvers[].is_codeowner",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_approvers[].updated_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_approvers[].avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_testers[].id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_testers[].username",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_testers[].name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_testers[].nick_name",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_testers[].name_cn",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_testers[].email",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_testers[].state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_testers[].is_codeowner",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_testers[].updated_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "approval_merge_request_testers[].avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "source_project.description",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.name_with_namespace",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.path",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.path_with_namespace",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.develop_mode",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.updated_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.archived",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "source_project.is_kia",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "source_project.ssh_url_to_repo",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.http_url_to_repo",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.web_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.readme_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.product_id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.product_name",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.member_mgnt_mode",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "source_project.default_branch",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.tag_list[]",
+      "type": "object",
+      "description": ""
+    },
+    {
+      "name": "source_project.license_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.license.key",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.license.name",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.license.nickname",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.license.html_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.license.source_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.avatar_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.star_count",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "source_project.forks_count",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "source_project.open_issues_count",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "source_project.open_merge_requests_count",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "source_project.open_change_requests_count",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.watch_count",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "source_project.last_activity_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.namespace.id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "source_project.namespace.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.namespace.path",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.namespace.develop_mode",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.namespace.region",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.namespace.cell",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.namespace.kind",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.namespace.full_path",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.namespace.full_name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.namespace.parent_id",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.namespace.visibility_level",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "source_project.namespace.enable_file_control",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.namespace.owner_id",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.empty_repo",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "source_project.starred",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "source_project.visibility",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.security",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.has_updated_kia",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "source_project.network_type",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.owner",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.creator.id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "source_project.creator.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.creator.username",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.creator.iam_id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.creator.nick_name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.creator.state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.creator.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.creator.avatar_path",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.creator.email",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.creator.name_cn",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.creator.web_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.creator.tenant_name",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.creator.is_member",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.creator_id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "source_project.forked_from_project",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.item_type",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "source_project.main_repository_language[]",
+      "type": "array<string>",
+      "description": ""
+    },
+    {
+      "name": "source_project.mirror_project_data",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.statistics",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.branch_count",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.tag_count",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.member_count",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.repo_replica_urls",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_project.open_external_wiki",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "source_project.release_count",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "target_project.description",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.name_with_namespace",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.path",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.path_with_namespace",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.develop_mode",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.updated_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.archived",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "target_project.is_kia",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "target_project.ssh_url_to_repo",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.http_url_to_repo",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.web_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.readme_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.product_id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.product_name",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.member_mgnt_mode",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "target_project.default_branch",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.tag_list[]",
+      "type": "object",
+      "description": ""
+    },
+    {
+      "name": "target_project.license_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.license.key",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.license.name",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.license.nickname",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.license.html_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.license.source_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.avatar_url",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.star_count",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "target_project.forks_count",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "target_project.open_issues_count",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "target_project.open_merge_requests_count",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "target_project.open_change_requests_count",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.watch_count",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "target_project.last_activity_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.namespace.id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "target_project.namespace.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.namespace.path",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.namespace.develop_mode",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.namespace.region",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.namespace.cell",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.namespace.kind",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.namespace.full_path",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.namespace.full_name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.namespace.parent_id",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.namespace.visibility_level",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "target_project.namespace.enable_file_control",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.namespace.owner_id",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.empty_repo",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "target_project.starred",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "target_project.visibility",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.security",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.has_updated_kia",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "target_project.network_type",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.owner",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.creator.id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "target_project.creator.name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.creator.username",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.creator.iam_id",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.creator.nick_name",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.creator.state",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.creator.avatar_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.creator.avatar_path",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.creator.email",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.creator.name_cn",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.creator.web_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.creator.tenant_name",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.creator.is_member",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.creator_id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "target_project.forked_from_project",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.item_type",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "target_project.main_repository_language[]",
+      "type": "array<string>",
+      "description": ""
+    },
+    {
+      "name": "target_project.mirror_project_data",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.statistics",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.branch_count",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.tag_count",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.member_count",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.repo_replica_urls",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "target_project.open_external_wiki",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "target_project.release_count",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "added_lines",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "removed_lines",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "subscribed",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "changes_count",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "latest_build_started_at",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "latest_build_finished_at",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "first_deployed_to_production_at",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "pipeline",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "diff_refs.base_sha",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "diff_refs.head_sha",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "diff_refs.start_sha",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "merge_error",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "json_merge_error",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "rebase_in_progress",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "diverged_commits_count",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "merge_request_assignee_list[]",
+      "type": "object",
+      "description": ""
+    },
+    {
+      "name": "merge_request_reviewer_list[]",
+      "type": "object",
+      "description": ""
+    },
+    {
+      "name": "user.can_merge",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "merge_request_review_count",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "merge_request_reviewers_count",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "notes",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "unresolved_discussions_count",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "e2e_issues[].id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "e2e_issues[].issue_type",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "e2e_issues[].linked_issue_type",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "e2e_issues[].issue_num",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "e2e_issues[].commit_id",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "e2e_issues[].merge_request_id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "e2e_issues[].check_fail_reason",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "e2e_issues[].check_result",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "e2e_issues[].issue_link",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "e2e_issues[].created_at",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "e2e_issues[].mks_id",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "e2e_issues[].pbi_id",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "e2e_issues[].pbi_name",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "e2e_issues[].source",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "e2e_issues[].issue_project_id",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "e2e_issues[].title",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "e2e_issues[].issue_project",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "e2e_issues[].auto_c_when_mr_merged",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "gate_check",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "head_pipeline_id",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "pipeline_status",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "codequality_status",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "pipeline_status_with_code_quality",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "from_forked_project",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "forked_project_name",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "can_delete_source_branch",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "required_reviewers[]",
+      "type": "object",
+      "description": ""
+    },
+    {
+      "name": "omega_mode",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "root_mr_locked_detail",
+      "type": "null",
+      "description": ""
+    },
+    {
+      "name": "source_git_url",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "auto_merge",
+      "type": "null",
+      "description": ""
+    }
+  ],
+  "responseExample": {
+    "id": 11264998,
+    "url": "https://gitcode.com/api/v5/repos/zzero/demo/pulls/6",
+    "html_url": "https://gitcode.com/zzero/demo/pulls/6",
+    "diff_url": "https://gitcode.com/zzero/demo/pulls/6.diff",
+    "patch_url": "https://gitcode.com/zzero/demo/pulls/6.patch",
+    "issue_url": "https://gitcode.com/api/v5/repos/zzero/demo/pulls/6/issues",
+    "commits_url": "https://gitcode.com/api/v5/repos/zzero/demo/pulls/6/commits",
+    "review_comments_url": "https://gitcode.com/api/v5/repos/zzero/demo/pulls/comments/{/number}",
+    "review_comment_url": "https://gitcode.com/api/v5/repos/zzero/demo/pulls/comments",
+    "comments_url": "https://gitcode.com/api/v5/repos/zzero/demo/pulls/6/comments",
+    "number": 6,
+    "title": "测试创建PR",
+    "description": "update: 更新文件 dev_001.txt \nupdate: 更新文件 dev_001.txt ",
+    "state": "opened",
+    "created_at": "2024-04-14T20:53:13.185+08:00",
+    "updated_at": "2024-04-14T20:53:22.634+08:00",
+    "merged_by": null,
+    "merged_at": null,
+    "closed_by": null,
+    "closed_at": null,
+    "title_html": null,
+    "description_html": null,
+    "target_branch": "test_b5",
+    "source_branch": "dev",
+    "squash_commit_message": null,
+    "user_notes_count": 0,
+    "upvotes": 0,
+    "downvotes": 0,
+    "author": {
+      "id": 494,
+      "name": "csdntest13",
+      "username": "csdntest13",
+      "iam_id": "d8b3e018b2364546b946886a669d50fc",
+      "nick_name": "csdntest13_gitcode",
+      "state": "active",
+      "avatar_url": "https://gitcode-img.obs.cn-south-1.myhuaweicloud.com:443/ec/ba/4e7c4661b6154a7dd088d9fe64b4893383a2e318bf362350ce18d44df6ac7e37.png?time=1711533165876",
+      "avatar_path": null,
+      "email": "csdntest13@noreply.gitcode.com",
+      "name_cn": "csdntest13",
+      "web_url": "https://gitcode.com/csdntest13",
+      "tenant_name": null,
+      "is_member": null
+    },
+    "assignee": null,
+    "source_project_id": 243377,
+    "target_project_id": 243377,
+    "labels": [
+      {
+        "color": "#008672",
+        "name": "help wanted",
+        "id": 381445,
+        "title": "help wanted",
+        "type": null,
+        "textColor": "#FFFFFF"
+      },
+      {
+        "color": "#CFD240",
+        "name": "invalid",
+        "id": 381446,
+        "title": "invalid",
+        "type": null,
+        "textColor": "#FFFFFF"
+      },
+      {
+        "color": "#D876E3",
+        "name": "question",
+        "id": 381447,
+        "title": "question",
+        "type": null,
+        "textColor": "#333333"
+      }
+    ],
+    "work_in_progress": false,
+    "milestone": null,
+    "merge_when_pipeline_succeeds": false,
+    "merge_status": "unchecked",
+    "sha": "8da7a5c35e71deeb0bf1d9ecae70449c574749f2",
+    "merge_commit_sha": null,
+    "discussion_locked": null,
+    "should_remove_source_branch": false,
+    "force_remove_source_branch": false,
+    "allow_collaboration": null,
+    "allow_maintainer_to_push": null,
+    "web_url": "https://gitcode.com/One/One/merge_requests/53",
+    "time_stats": {
+      "time_estimate": null,
+      "total_time_spent": 0,
+      "human_time_estimate": null,
+      "human_total_time_spent": null
+    },
+    "squash": false,
+    "merge_request_type": "MergeRequest",
+    "has_pre_merge_ref": false,
+    "review_mode": "approval",
+    "is_source_branch_exist": true,
+    "approval_merge_request_reviewers": [
+      {
+        "id": 43,
+        "username": "green",
+        "name": "green",
+        "nick_name": null,
+        "name_cn": "green",
+        "email": null,
+        "state": "optional",
+        "is_codeowner": false,
+        "updated_at": "2024-04-14T20:53:23.021+08:00",
+        "avatar_url": "https://gitcode-img.obs.cn-south-1.myhuaweicloud.com:443/be/fb/7b9e393fbd80ca315dec249f2be6e6a7378f591609b6525798bc6d95abedc992.png?time=1712128581171"
+      }
+    ],
+    "approval_merge_request_approvers": [
+      {
+        "id": 277,
+        "username": "renww",
+        "name": "renww",
+        "nick_name": null,
+        "name_cn": "renww",
+        "email": null,
+        "state": "optional",
+        "is_codeowner": false,
+        "updated_at": "2024-04-14T20:53:23.751+08:00",
+        "avatar_url": "https://gitcode-img.obs.cn-south-1.myhuaweicloud.com:443/ee/dc/7602704ee7dcf13f4383a72d492b1813823afba729ae6e9115877a4a0128d990.jpg?time=1711447395118"
+      }
+    ],
+    "approval_merge_request_testers": [
+      {
+        "id": 43,
+        "username": "green",
+        "name": "green",
+        "nick_name": null,
+        "name_cn": "green",
+        "email": null,
+        "state": "optional",
+        "is_codeowner": false,
+        "updated_at": "2024-04-14T20:53:23.755+08:00",
+        "avatar_url": "https://gitcode-img.obs.cn-south-1.myhuaweicloud.com:443/be/fb/7b9e393fbd80ca315dec249f2be6e6a7378f591609b6525798bc6d95abedc992.png?time=1712128581171"
+      },
+      {
+        "id": 277,
+        "username": "renww",
+        "name": "renww",
+        "nick_name": null,
+        "name_cn": "renww",
+        "email": null,
+        "state": "optional",
+        "is_codeowner": false,
+        "updated_at": "2024-04-14T20:53:23.755+08:00",
+        "avatar_url": "https://gitcode-img.obs.cn-south-1.myhuaweicloud.com:443/ee/dc/7602704ee7dcf13f4383a72d492b1813823afba729ae6e9115877a4a0128d990.jpg?time=1711447395118"
+      }
+    ],
+    "source_project": {
+      "id": 243377,
+      "description": "csdntest13的第一个项目(公开)",
+      "name": "One",
+      "name_with_namespace": "One / One",
+      "path": "One",
+      "path_with_namespace": "One/One",
+      "develop_mode": "normal",
+      "created_at": "2024-03-19T16:24:01.197+08:00",
+      "updated_at": "2024-03-19T16:42:34.834+08:00",
+      "archived": false,
+      "is_kia": false,
+      "ssh_url_to_repo": "ssh://git@gitcode.com:2222/One/One.git",
+      "http_url_to_repo": "https://gitcode.com/One/One.git",
+      "web_url": "https://gitcode.com/One/One",
+      "readme_url": "https://gitcode.com/One/One/blob/main/README.md",
+      "product_id": "28f96caf52004e81ab0bc38d60d11940",
+      "product_name": null,
+      "member_mgnt_mode": 3,
+      "default_branch": "main",
+      "tag_list": [],
+      "license_url": null,
+      "license": {
+        "key": "Apache_License_v2.0",
+        "name": null,
+        "nickname": null,
+        "html_url": null,
+        "source_url": null
+      },
+      "avatar_url": null,
+      "star_count": 1,
+      "forks_count": 0,
+      "open_issues_count": 108,
+      "open_merge_requests_count": 32,
+      "open_change_requests_count": null,
+      "watch_count": 1,
+      "last_activity_at": "2024-04-14T20:43:58.602+08:00",
+      "namespace": {
+        "id": 136909,
+        "name": "One",
+        "path": "One",
+        "develop_mode": "normal",
+        "region": null,
+        "cell": "default",
+        "kind": "group",
+        "full_path": "One",
+        "full_name": "One ",
+        "parent_id": null,
+        "visibility_level": 20,
+        "enable_file_control": null,
+        "owner_id": null
+      },
+      "empty_repo": false,
+      "starred": false,
+      "visibility": "public",
+      "security": "internal",
+      "has_updated_kia": false,
+      "network_type": "green",
+      "owner": null,
+      "creator": {
+        "id": 494,
+        "name": "csdntest13",
+        "username": "csdntest13",
+        "iam_id": "d8b3e018b2364546b946886a669d50fc",
+        "nick_name": "csdntest13_gitcode",
+        "state": "active",
+        "avatar_url": "https://gitcode-img.obs.cn-south-1.myhuaweicloud.com:443/ec/ba/4e7c4661b6154a7dd088d9fe64b4893383a2e318bf362350ce18d44df6ac7e37.png?time=1711533165876",
+        "avatar_path": null,
+        "email": "csdntest13@noreply.gitcode.com",
+        "name_cn": "csdntest13",
+        "web_url": "https://gitcode.com/csdntest13",
+        "tenant_name": null,
+        "is_member": null
+      },
+      "creator_id": 494,
+      "forked_from_project": null,
+      "item_type": "Project",
+      "main_repository_language": [
+        "Text",
+        "#cccccc"
+      ],
+      "mirror_project_data": null,
+      "statistics": null,
+      "branch_count": null,
+      "tag_count": null,
+      "member_count": null,
+      "repo_replica_urls": null,
+      "open_external_wiki": true,
+      "release_count": null
+    },
+    "target_project": {
+      "id": 243377,
+      "description": "csdntest13的第一个项目(公开)",
+      "name": "One",
+      "name_with_namespace": "One / One",
+      "path": "One",
+      "path_with_namespace": "One/One",
+      "develop_mode": "normal",
+      "created_at": "2024-03-19T16:24:01.197+08:00",
+      "updated_at": "2024-03-19T16:42:34.834+08:00",
+      "archived": false,
+      "is_kia": false,
+      "ssh_url_to_repo": "ssh://git@gitcode.com:2222/One/One.git",
+      "http_url_to_repo": "https://gitcode.com/One/One.git",
+      "web_url": "https://gitcode.com/One/One",
+      "readme_url": "https://gitcode.com/One/One/blob/main/README.md",
+      "product_id": "28f96caf52004e81ab0bc38d60d11940",
+      "product_name": null,
+      "member_mgnt_mode": 3,
+      "default_branch": "main",
+      "tag_list": [],
+      "license_url": null,
+      "license": {
+        "key": "Apache_License_v2.0",
+        "name": null,
+        "nickname": null,
+        "html_url": null,
+        "source_url": null
+      },
+      "avatar_url": null,
+      "star_count": 1,
+      "forks_count": 0,
+      "open_issues_count": 108,
+      "open_merge_requests_count": 32,
+      "open_change_requests_count": null,
+      "watch_count": 1,
+      "last_activity_at": "2024-04-14T20:43:58.602+08:00",
+      "namespace": {
+        "id": 136909,
+        "name": "One",
+        "path": "One",
+        "develop_mode": "normal",
+        "region": null,
+        "cell": "default",
+        "kind": "group",
+        "full_path": "One",
+        "full_name": "One ",
+        "parent_id": null,
+        "visibility_level": 20,
+        "enable_file_control": null,
+        "owner_id": null
+      },
+      "empty_repo": false,
+      "starred": false,
+      "visibility": "public",
+      "security": "internal",
+      "has_updated_kia": false,
+      "network_type": "green",
+      "owner": null,
+      "creator": {
+        "id": 494,
+        "name": "csdntest13",
+        "username": "csdntest13",
+        "iam_id": "d8b3e018b2364546b946886a669d50fc",
+        "nick_name": "csdntest13_gitcode",
+        "state": "active",
+        "avatar_url": "https://gitcode-img.obs.cn-south-1.myhuaweicloud.com:443/ec/ba/4e7c4661b6154a7dd088d9fe64b4893383a2e318bf362350ce18d44df6ac7e37.png?time=1711533165876",
+        "avatar_path": null,
+        "email": "csdntest13@noreply.gitcode.com",
+        "name_cn": "csdntest13",
+        "web_url": "https://gitcode.com/csdntest13",
+        "tenant_name": null,
+        "is_member": null
+      },
+      "creator_id": 494,
+      "forked_from_project": null,
+      "item_type": "Project",
+      "main_repository_language": [
+        "Text",
+        "#cccccc"
+      ],
+      "mirror_project_data": null,
+      "statistics": null,
+      "branch_count": null,
+      "tag_count": null,
+      "member_count": null,
+      "repo_replica_urls": null,
+      "open_external_wiki": true,
+      "release_count": null
+    },
+    "added_lines": 19860,
+    "removed_lines": 1,
+    "subscribed": true,
+    "changes_count": "6",
+    "latest_build_started_at": null,
+    "latest_build_finished_at": null,
+    "first_deployed_to_production_at": null,
+    "pipeline": null,
+    "diff_refs": {
+      "base_sha": "0c02dd57f8945791460a141f155dd2f4bd5dea86",
+      "head_sha": "8da7a5c35e71deeb0bf1d9ecae70449c574749f2",
+      "start_sha": "fb6495834d1bf7a39dfdb44ad25e6f83c7136310"
+    },
+    "merge_error": null,
+    "json_merge_error": null,
+    "rebase_in_progress": null,
+    "diverged_commits_count": null,
+    "merge_request_assignee_list": [],
+    "merge_request_reviewer_list": [],
+    "user": {
+      "can_merge": true
+    },
+    "merge_request_review_count": 0,
+    "merge_request_reviewers_count": 0,
+    "notes": 0,
+    "unresolved_discussions_count": 0,
+    "e2e_issues": [
+      {
+        "id": 13588,
+        "issue_type": 7,
+        "linked_issue_type": null,
+        "issue_num": "issue100",
+        "commit_id": null,
+        "merge_request_id": 68253,
+        "check_fail_reason": "",
+        "check_result": true,
+        "issue_link": "https://gitcode.com/One/One/issues/100",
+        "created_at": "2024-04-14T20:53:23.772+08:00",
+        "mks_id": null,
+        "pbi_id": null,
+        "pbi_name": null,
+        "source": null,
+        "issue_project_id": 243377,
+        "title": "第boudoirripinings-45个issue",
+        "issue_project": null,
+        "auto_c_when_mr_merged": false
+      }
+    ],
+    "gate_check": true,
+    "head_pipeline_id": null,
+    "pipeline_status": "",
+    "codequality_status": "success",
+    "pipeline_status_with_code_quality": "",
+    "from_forked_project": false,
+    "forked_project_name": null,
+    "can_delete_source_branch": true,
+    "required_reviewers": [],
+    "omega_mode": false,
+    "root_mr_locked_detail": null,
+    "source_git_url": "ssh://git@gitcode.com:2222/One/One.git",
+    "auto_merge": null
+  },
+  "curlExample": "curl -X POST \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/pulls?access_token=YOUR_TOKEN\" \\\\\n  -H \"Accept: application/json\"\n  -H \"Content-Type: application/json\" \\\\\n  -d '{\n  \"title\": \"value\"\n}'",
+  "pythonExample": "import requests\n\nurl = \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/pulls\"\nparams = {\"access_token\": \"YOUR_TOKEN\"}\nheaders = {\"Accept\": \"application/json\"}\ndata = {\n    \"title\": \"value\"\n}\n\nresponse = requests.post(url, headers=headers, params=params, json=data)\nprint(response.json())",
+  "dataSource": "frontMatter.api",
+  "status": "done",
+  "notes": "",
+  "metadata": {
+    "chunkUrl": "https://docs.gitcode.com/assets/js/e68328ef.c702df98.js",
+    "sourceType": "openapi",
+    "titleFrom": "metadata.title"
+  }
+}

--- a/tests/fixtures/gitcode-api-contracts/raw/Pull Requests/put-api-v-5-repos-owner-repo-pulls-number-merge.json
+++ b/tests/fixtures/gitcode-api-contracts/raw/Pull Requests/put-api-v-5-repos-owner-repo-pulls-number-merge.json
@@ -1,0 +1,95 @@
+{
+  "category": "Pull Requests",
+  "name": "合并Pull Request",
+  "slug": "put-api-v-5-repos-owner-repo-pulls-number-merge",
+  "docUrl": "https://docs.gitcode.com/docs/apis/put-api-v-5-repos-owner-repo-pulls-number-merge",
+  "summary": "",
+  "method": "PUT",
+  "path": "/api/v5/repos/{owner}/{repo}/pulls/{number}/merge",
+  "pathParams": [
+    {
+      "name": "owner",
+      "type": "string",
+      "required": true,
+      "description": "仓库所属空间地址(组织或个人的地址path)"
+    },
+    {
+      "name": "repo",
+      "type": "string",
+      "required": true,
+      "description": "仓库路径(path)"
+    },
+    {
+      "name": "number",
+      "type": "integer",
+      "required": true,
+      "description": "第几个PR，即本仓库PR的序数"
+    }
+  ],
+  "queryParams": [
+    {
+      "name": "access_token",
+      "type": "string",
+      "required": true,
+      "description": "用户授权码"
+    }
+  ],
+  "requestBodyFields": [
+    {
+      "name": "merge_method",
+      "type": "string",
+      "required": false,
+      "description": "可选。合并PR的方法，merge（合并所有提交）、squash（扁平化分支合并）和rebase（变基并合并）。默认为merge。"
+    },
+    {
+      "name": "title",
+      "type": "string",
+      "required": false,
+      "description": "可选。合并标题"
+    },
+    {
+      "name": "description",
+      "type": "string",
+      "required": false,
+      "description": "可选。合并描述"
+    },
+    {
+      "name": "force_merge",
+      "type": "boolean",
+      "required": false,
+      "description": "是否强制合并（需开启“允许管理员强制合入”设置，并且需管理员权限）"
+    }
+  ],
+  "responseFields": [
+    {
+      "name": "sha",
+      "type": "string",
+      "description": ""
+    },
+    {
+      "name": "merged",
+      "type": "integer",
+      "description": ""
+    },
+    {
+      "name": "message",
+      "type": "string",
+      "description": ""
+    }
+  ],
+  "responseExample": {
+    "sha": "c20ac9624d2811a9313af29769dcf581b60c3044",
+    "merged": true,
+    "message": "Pull Request已成功合并"
+  },
+  "curlExample": "curl -X PUT \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/pulls/number_value/merge?access_token=YOUR_TOKEN\" \\\\\n  -H \"Accept: application/json\"\n  -H \"Content-Type: application/json\" \\\\\n  -d '{\n  \"merge_method\": \"value\"\n}'",
+  "pythonExample": "import requests\n\nurl = \"https://api.gitcode.com/api/v5/repos/owner_value/repo_value/pulls/number_value/merge\"\nparams = {\"access_token\": \"YOUR_TOKEN\"}\nheaders = {\"Accept\": \"application/json\"}\ndata = {\n    \"merge_method\": \"value\"\n}\n\nresponse = requests.put(url, headers=headers, params=params, json=data)\nprint(response.json())",
+  "dataSource": "frontMatter.api",
+  "status": "done",
+  "notes": "",
+  "metadata": {
+    "chunkUrl": "https://docs.gitcode.com/assets/js/1474b9ff.313556a8.js",
+    "sourceType": "openapi",
+    "titleFrom": "metadata.title"
+  }
+}

--- a/tests/unit/commands/test_cli_gh_compat.py
+++ b/tests/unit/commands/test_cli_gh_compat.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from click.testing import CliRunner
 
 from gitcode_cli.cli import main
+
+FIXTURE_PATH = Path(__file__).resolve().parents[2] / "fixtures" / "gh-cli-compat" / "command_baseline.json"
+GH_CLI_BASELINE = json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
 
 
 def _get_cli_flags(command_path: str) -> set[str]:
@@ -21,72 +27,36 @@ def _get_cli_flags(command_path: str) -> set[str]:
     return flags
 
 
-GH_ISSUE_LIST_FLAGS = {
-    "-s",
-    "-l",
-    "-A",
-    "-a",
-    "--milestone",
-    "--mention",
-    "--app",
-    "-S",
-    "-L",
-    "-w",
-    "--json",
-    "-q",
-    "-t",
-    "-R",
-}
+def _assert_subcommands(group: str) -> None:
+    result = CliRunner().invoke(main, [group, "--help"])
+    for command_name in GH_CLI_BASELINE[group]["subcommands"]:
+        assert command_name in result.output
 
-GH_ISSUE_VIEW_FLAGS = {"-c", "-w", "--json", "-q", "-t", "-R"}
 
-GH_ISSUE_CREATE_FLAGS = {
-    "-t",
-    "-b",
-    "-F",
-    "-e",
-    "-l",
-    "-m",
-    "-a",
-    "-w",
-    "-R",
-}
-
-GH_ISSUE_CLOSE_FLAGS = {"-c", "-r", "--duplicate-of", "-R"}
-
-GH_ISSUE_COMMENT_FLAGS = {"-b", "-F", "-e", "-w", "--delete-last", "--edit-last", "-R"}
+def _assert_command_flags(command_path: str) -> None:
+    flags = _get_cli_flags(command_path)
+    for flag in GH_CLI_BASELINE[command_path.split()[0]]["commands"][command_path]["flags"]:
+        assert flag in flags, f"gh {command_path} flag {flag} missing from gc"
 
 
 class TestIssueCliGhCompatibility:
     def test_issue_subcommands_exist(self) -> None:
-        result = CliRunner().invoke(main, ["issue", "--help"])
-        for cmd in ("list", "view", "create", "close", "comment"):
-            assert cmd in result.output
+        _assert_subcommands("issue")
 
     def test_issue_list_has_gh_flags(self) -> None:
-        flags = _get_cli_flags("issue list")
-        for flag in GH_ISSUE_LIST_FLAGS:
-            assert flag in flags, f"gh issue list flag {flag} missing from gc"
+        _assert_command_flags("issue list")
 
     def test_issue_view_has_gh_flags(self) -> None:
-        flags = _get_cli_flags("issue view")
-        for flag in GH_ISSUE_VIEW_FLAGS:
-            assert flag in flags, f"gh issue view flag {flag} missing from gc"
+        _assert_command_flags("issue view")
 
     def test_issue_create_has_gh_flags(self) -> None:
-        flags = _get_cli_flags("issue create")
-        for flag in GH_ISSUE_CREATE_FLAGS:
-            assert flag in flags, f"gh issue create flag {flag} missing from gc"
+        _assert_command_flags("issue create")
 
     def test_issue_close_has_gh_flags(self) -> None:
-        flags = _get_cli_flags("issue close")
-        for flag in GH_ISSUE_CLOSE_FLAGS:
-            assert flag in flags, f"gh issue close flag {flag} missing from gc"
+        _assert_command_flags("issue close")
 
     def test_issue_comment_has_gh_flags(self) -> None:
-        flags = _get_cli_flags("issue comment")
-        for flag in GH_ISSUE_COMMENT_FLAGS:
-            assert flag in flags, f"gh issue comment flag {flag} missing from gc"
+        _assert_command_flags("issue comment")
 
     def test_issue_list_rejects_invalid_limit(self) -> None:
         result = CliRunner().invoke(main, ["issue", "list", "-L", "0"])
@@ -94,103 +64,27 @@ class TestIssueCliGhCompatibility:
         assert "must be greater than 0" in result.output
 
 
-GH_PR_LIST_FLAGS = {
-    "-s",
-    "-A",
-    "-B",
-    "-a",
-    "-d",
-    "-H",
-    "-l",
-    "-S",
-    "-L",
-    "-w",
-    "--json",
-    "-q",
-    "-t",
-    "-R",
-}
-
-GH_PR_VIEW_FLAGS = {"-c", "-w", "--json", "-q", "-t", "-R"}
-
-GH_PR_CREATE_FLAGS = {
-    "-t",
-    "-b",
-    "-F",
-    "-e",
-    "-f",
-    "-d",
-    "-B",
-    "-H",
-    "-l",
-    "-r",
-    "-a",
-    "-m",
-    "-w",
-    "--json",
-    "-q",
-    "-R",
-    "--dry-run",
-}
-
-GH_PR_CLOSE_FLAGS = {"-c", "-d", "-R"}
-
-GH_PR_MERGE_FLAGS = {
-    "-m",
-    "-s",
-    "-r",
-    "-d",
-    "-b",
-    "-F",
-    "-t",
-    "-A",
-    "--auto",
-    "--admin",
-    "-R",
-}
-
-GH_PR_COMMENT_FLAGS = {"-b", "-F", "-e", "-w", "-R"}
-
-GH_PR_REVIEW_FLAGS = {"-a", "-b", "-F", "-c", "-r", "-R"}
-
-
 class TestPrCliGhCompatibility:
     def test_pr_subcommands_exist(self) -> None:
-        result = CliRunner().invoke(main, ["pr", "--help"])
-        for cmd in ("list", "view", "create", "close", "merge", "comment", "review"):
-            assert cmd in result.output
+        _assert_subcommands("pr")
 
     def test_pr_list_has_gh_flags(self) -> None:
-        flags = _get_cli_flags("pr list")
-        for flag in GH_PR_LIST_FLAGS:
-            assert flag in flags, f"gh pr list flag {flag} missing from gc"
+        _assert_command_flags("pr list")
 
     def test_pr_view_has_gh_flags(self) -> None:
-        flags = _get_cli_flags("pr view")
-        for flag in GH_PR_VIEW_FLAGS:
-            assert flag in flags, f"gh pr view flag {flag} missing from gc"
+        _assert_command_flags("pr view")
 
     def test_pr_create_has_gh_flags(self) -> None:
-        flags = _get_cli_flags("pr create")
-        for flag in GH_PR_CREATE_FLAGS:
-            assert flag in flags, f"gh pr create flag {flag} missing from gc"
+        _assert_command_flags("pr create")
 
     def test_pr_close_has_gh_flags(self) -> None:
-        flags = _get_cli_flags("pr close")
-        for flag in GH_PR_CLOSE_FLAGS:
-            assert flag in flags, f"gh pr close flag {flag} missing from gc"
+        _assert_command_flags("pr close")
 
     def test_pr_merge_has_gh_flags(self) -> None:
-        flags = _get_cli_flags("pr merge")
-        for flag in GH_PR_MERGE_FLAGS:
-            assert flag in flags, f"gh pr merge flag {flag} missing from gc"
+        _assert_command_flags("pr merge")
 
     def test_pr_comment_has_gh_flags(self) -> None:
-        flags = _get_cli_flags("pr comment")
-        for flag in GH_PR_COMMENT_FLAGS:
-            assert flag in flags, f"gh pr comment flag {flag} missing from gc"
+        _assert_command_flags("pr comment")
 
     def test_pr_review_has_gh_flags(self) -> None:
-        flags = _get_cli_flags("pr review")
-        for flag in GH_PR_REVIEW_FLAGS:
-            assert flag in flags, f"gh pr review flag {flag} missing from gc"
+        _assert_command_flags("pr review")

--- a/tests/unit/commands/test_cli_gh_compat.py
+++ b/tests/unit/commands/test_cli_gh_compat.py
@@ -35,7 +35,8 @@ def _assert_subcommands(group: str) -> None:
 
 def _assert_command_flags(command_path: str) -> None:
     flags = _get_cli_flags(command_path)
-    for flag in GH_CLI_BASELINE[command_path.split()[0]]["commands"][command_path]["flags"]:
+    group = command_path.split(maxsplit=1)[0]
+    for flag in GH_CLI_BASELINE[group]["commands"][command_path]["flags"]:
         assert flag in flags, f"gh {command_path} flag {flag} missing from gc"
 
 

--- a/tests/unit/commands/test_cli_gh_compat.py
+++ b/tests/unit/commands/test_cli_gh_compat.py
@@ -21,35 +21,71 @@ def _get_cli_flags(command_path: str) -> set[str]:
     return flags
 
 
+GH_ISSUE_LIST_FLAGS = {
+    "-s",
+    "-l",
+    "-A",
+    "-a",
+    "--milestone",
+    "--mention",
+    "--app",
+    "-S",
+    "-L",
+    "-w",
+    "--json",
+    "-q",
+    "-t",
+    "-R",
+}
+
+GH_ISSUE_VIEW_FLAGS = {"-c", "-w", "--json", "-q", "-t", "-R"}
+
+GH_ISSUE_CREATE_FLAGS = {
+    "-t",
+    "-b",
+    "-F",
+    "-e",
+    "-l",
+    "-m",
+    "-a",
+    "-w",
+    "-R",
+}
+
+GH_ISSUE_CLOSE_FLAGS = {"-c", "-r", "--duplicate-of", "-R"}
+
+GH_ISSUE_COMMENT_FLAGS = {"-b", "-F", "-e", "-w", "--delete-last", "--edit-last", "-R"}
+
+
 class TestIssueCliGhCompatibility:
     def test_issue_subcommands_exist(self) -> None:
         result = CliRunner().invoke(main, ["issue", "--help"])
         for cmd in ("list", "view", "create", "close", "comment"):
             assert cmd in result.output
 
-    def test_issue_list_accepts_gh_flags(self) -> None:
+    def test_issue_list_has_gh_flags(self) -> None:
         flags = _get_cli_flags("issue list")
-        for flag in ("-s", "-l", "-A", "-a", "--milestone", "--mention", "-S", "-L", "-w", "--json", "-q", "-t", "-R"):
+        for flag in GH_ISSUE_LIST_FLAGS:
             assert flag in flags, f"gh issue list flag {flag} missing from gc"
 
-    def test_issue_view_accepts_gh_flags(self) -> None:
+    def test_issue_view_has_gh_flags(self) -> None:
         flags = _get_cli_flags("issue view")
-        for flag in ("-w", "-c", "--json", "-q", "-t", "-R"):
+        for flag in GH_ISSUE_VIEW_FLAGS:
             assert flag in flags, f"gh issue view flag {flag} missing from gc"
 
-    def test_issue_create_accepts_gh_flags(self) -> None:
+    def test_issue_create_has_gh_flags(self) -> None:
         flags = _get_cli_flags("issue create")
-        for flag in ("-t", "-b", "-a", "-l", "-m", "-F", "-w", "--json", "-q", "-t", "-R"):
+        for flag in GH_ISSUE_CREATE_FLAGS:
             assert flag in flags, f"gh issue create flag {flag} missing from gc"
 
-    def test_issue_close_accepts_gh_flags(self) -> None:
+    def test_issue_close_has_gh_flags(self) -> None:
         flags = _get_cli_flags("issue close")
-        for flag in ("-c", "-r", "-R"):
+        for flag in GH_ISSUE_CLOSE_FLAGS:
             assert flag in flags, f"gh issue close flag {flag} missing from gc"
 
-    def test_issue_comment_accepts_gh_flags(self) -> None:
+    def test_issue_comment_has_gh_flags(self) -> None:
         flags = _get_cli_flags("issue comment")
-        for flag in ("-b", "-F", "-e", "-R"):
+        for flag in GH_ISSUE_COMMENT_FLAGS:
             assert flag in flags, f"gh issue comment flag {flag} missing from gc"
 
     def test_issue_list_rejects_invalid_limit(self) -> None:
@@ -58,74 +94,103 @@ class TestIssueCliGhCompatibility:
         assert "must be greater than 0" in result.output
 
 
+GH_PR_LIST_FLAGS = {
+    "-s",
+    "-A",
+    "-B",
+    "-a",
+    "-d",
+    "-H",
+    "-l",
+    "-S",
+    "-L",
+    "-w",
+    "--json",
+    "-q",
+    "-t",
+    "-R",
+}
+
+GH_PR_VIEW_FLAGS = {"-c", "-w", "--json", "-q", "-t", "-R"}
+
+GH_PR_CREATE_FLAGS = {
+    "-t",
+    "-b",
+    "-F",
+    "-e",
+    "-f",
+    "-d",
+    "-B",
+    "-H",
+    "-l",
+    "-r",
+    "-a",
+    "-m",
+    "-w",
+    "--json",
+    "-q",
+    "-R",
+    "--dry-run",
+}
+
+GH_PR_CLOSE_FLAGS = {"-c", "-d", "-R"}
+
+GH_PR_MERGE_FLAGS = {
+    "-m",
+    "-s",
+    "-r",
+    "-d",
+    "-b",
+    "-F",
+    "-t",
+    "-A",
+    "--auto",
+    "--admin",
+    "-R",
+}
+
+GH_PR_COMMENT_FLAGS = {"-b", "-F", "-e", "-w", "-R"}
+
+GH_PR_REVIEW_FLAGS = {"-a", "-b", "-F", "-c", "-r", "-R"}
+
+
 class TestPrCliGhCompatibility:
     def test_pr_subcommands_exist(self) -> None:
         result = CliRunner().invoke(main, ["pr", "--help"])
         for cmd in ("list", "view", "create", "close", "merge", "comment", "review"):
             assert cmd in result.output
 
-    def test_pr_list_accepts_gh_flags(self) -> None:
+    def test_pr_list_has_gh_flags(self) -> None:
         flags = _get_cli_flags("pr list")
-        for flag in (
-            "-s",
-            "-A",
-            "-B",
-            "--assignee",
-            "--draft",
-            "--head",
-            "-l",
-            "-S",
-            "-L",
-            "-w",
-            "--json",
-            "-q",
-            "-t",
-            "-R",
-        ):
+        for flag in GH_PR_LIST_FLAGS:
             assert flag in flags, f"gh pr list flag {flag} missing from gc"
 
-    def test_pr_view_accepts_gh_flags(self) -> None:
+    def test_pr_view_has_gh_flags(self) -> None:
         flags = _get_cli_flags("pr view")
-        for flag in ("-w", "-c", "--json", "-q", "-t", "-R"):
+        for flag in GH_PR_VIEW_FLAGS:
             assert flag in flags, f"gh pr view flag {flag} missing from gc"
 
-    def test_pr_create_accepts_gh_flags(self) -> None:
+    def test_pr_create_has_gh_flags(self) -> None:
         flags = _get_cli_flags("pr create")
-        for flag in (
-            "-t",
-            "-b",
-            "-F",
-            "-B",
-            "-H",
-            "-d",
-            "--milestone",
-            "-l",
-            "-r",
-            "-a",
-            "-w",
-            "--json",
-            "-q",
-            "-t",
-            "-R",
-        ):
+        for flag in GH_PR_CREATE_FLAGS:
             assert flag in flags, f"gh pr create flag {flag} missing from gc"
 
-    def test_pr_close_accepts_gh_flags(self) -> None:
+    def test_pr_close_has_gh_flags(self) -> None:
         flags = _get_cli_flags("pr close")
-        for flag in ("-c", "-d", "-R"):
+        for flag in GH_PR_CLOSE_FLAGS:
             assert flag in flags, f"gh pr close flag {flag} missing from gc"
 
-    def test_pr_merge_accepts_gh_flags(self) -> None:
+    def test_pr_merge_has_gh_flags(self) -> None:
         flags = _get_cli_flags("pr merge")
-        for flag in ("-m", "-s", "-r", "-d", "-R"):
+        for flag in GH_PR_MERGE_FLAGS:
             assert flag in flags, f"gh pr merge flag {flag} missing from gc"
 
-    def test_pr_comment_accepts_gh_flags(self) -> None:
+    def test_pr_comment_has_gh_flags(self) -> None:
         flags = _get_cli_flags("pr comment")
-        for flag in ("-b", "-F", "-e", "-w", "--path", "--position", "-R"):
+        for flag in GH_PR_COMMENT_FLAGS:
             assert flag in flags, f"gh pr comment flag {flag} missing from gc"
 
-    def test_pr_review_accepts_gh_flags(self) -> None:
+    def test_pr_review_has_gh_flags(self) -> None:
         flags = _get_cli_flags("pr review")
-        for flag in ("-a", "--body", "--comment", "--request-changes", "-R"):
+        for flag in GH_PR_REVIEW_FLAGS:
             assert flag in flags, f"gh pr review flag {flag} missing from gc"

--- a/tests/unit/commands/test_cli_gh_compat.py
+++ b/tests/unit/commands/test_cli_gh_compat.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from gitcode_cli.cli import main
+
+
+def _get_cli_flags(command_path: str) -> set[str]:
+    result = CliRunner().invoke(main, command_path.split() + ["--help"])
+    flags: set[str] = set()
+    for line in result.output.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("-") or stripped.startswith("--"):
+            flag = stripped.split(",")[0].split()[0]
+            flags.add(flag)
+    if not flags:
+        raise AssertionError(
+            f"No flags parsed from help output for '{command_path}'. "
+            f"Exit code: {result.exit_code}, output: {result.output[:300]!r}"
+        )
+    return flags
+
+
+class TestIssueCliGhCompatibility:
+    def test_issue_subcommands_exist(self) -> None:
+        result = CliRunner().invoke(main, ["issue", "--help"])
+        for cmd in ("list", "view", "create", "close", "comment"):
+            assert cmd in result.output
+
+    def test_issue_list_accepts_gh_flags(self) -> None:
+        flags = _get_cli_flags("issue list")
+        for flag in ("-s", "-l", "-A", "-a", "--milestone", "--mention", "-S", "-L", "-w", "--json", "-q", "-t", "-R"):
+            assert flag in flags, f"gh issue list flag {flag} missing from gc"
+
+    def test_issue_view_accepts_gh_flags(self) -> None:
+        flags = _get_cli_flags("issue view")
+        for flag in ("-w", "-c", "--json", "-q", "-t", "-R"):
+            assert flag in flags, f"gh issue view flag {flag} missing from gc"
+
+    def test_issue_create_accepts_gh_flags(self) -> None:
+        flags = _get_cli_flags("issue create")
+        for flag in ("-t", "-b", "-a", "-l", "-m", "-F", "-w", "--json", "-q", "-t", "-R"):
+            assert flag in flags, f"gh issue create flag {flag} missing from gc"
+
+    def test_issue_close_accepts_gh_flags(self) -> None:
+        flags = _get_cli_flags("issue close")
+        for flag in ("-c", "-r", "-R"):
+            assert flag in flags, f"gh issue close flag {flag} missing from gc"
+
+    def test_issue_comment_accepts_gh_flags(self) -> None:
+        flags = _get_cli_flags("issue comment")
+        for flag in ("-b", "-F", "-e", "-R"):
+            assert flag in flags, f"gh issue comment flag {flag} missing from gc"
+
+    def test_issue_list_rejects_invalid_limit(self) -> None:
+        result = CliRunner().invoke(main, ["issue", "list", "-L", "0"])
+        assert result.exit_code != 0
+        assert "must be greater than 0" in result.output
+
+
+class TestPrCliGhCompatibility:
+    def test_pr_subcommands_exist(self) -> None:
+        result = CliRunner().invoke(main, ["pr", "--help"])
+        for cmd in ("list", "view", "create", "close", "merge", "comment", "review"):
+            assert cmd in result.output
+
+    def test_pr_list_accepts_gh_flags(self) -> None:
+        flags = _get_cli_flags("pr list")
+        for flag in (
+            "-s",
+            "-A",
+            "-B",
+            "--assignee",
+            "--draft",
+            "--head",
+            "-l",
+            "-S",
+            "-L",
+            "-w",
+            "--json",
+            "-q",
+            "-t",
+            "-R",
+        ):
+            assert flag in flags, f"gh pr list flag {flag} missing from gc"
+
+    def test_pr_view_accepts_gh_flags(self) -> None:
+        flags = _get_cli_flags("pr view")
+        for flag in ("-w", "-c", "--json", "-q", "-t", "-R"):
+            assert flag in flags, f"gh pr view flag {flag} missing from gc"
+
+    def test_pr_create_accepts_gh_flags(self) -> None:
+        flags = _get_cli_flags("pr create")
+        for flag in (
+            "-t",
+            "-b",
+            "-F",
+            "-B",
+            "-H",
+            "-d",
+            "--milestone",
+            "-l",
+            "-r",
+            "-a",
+            "-w",
+            "--json",
+            "-q",
+            "-t",
+            "-R",
+        ):
+            assert flag in flags, f"gh pr create flag {flag} missing from gc"
+
+    def test_pr_close_accepts_gh_flags(self) -> None:
+        flags = _get_cli_flags("pr close")
+        for flag in ("-c", "-d", "-R"):
+            assert flag in flags, f"gh pr close flag {flag} missing from gc"
+
+    def test_pr_merge_accepts_gh_flags(self) -> None:
+        flags = _get_cli_flags("pr merge")
+        for flag in ("-m", "-s", "-r", "-d", "-R"):
+            assert flag in flags, f"gh pr merge flag {flag} missing from gc"
+
+    def test_pr_comment_accepts_gh_flags(self) -> None:
+        flags = _get_cli_flags("pr comment")
+        for flag in ("-b", "-F", "-e", "-w", "--path", "--position", "-R"):
+            assert flag in flags, f"gh pr comment flag {flag} missing from gc"
+
+    def test_pr_review_accepts_gh_flags(self) -> None:
+        flags = _get_cli_flags("pr review")
+        for flag in ("-a", "--body", "--comment", "--request-changes", "-R"):
+            assert flag in flags, f"gh pr review flag {flag} missing from gc"

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -303,6 +303,15 @@ class TestIssueView:
         assert json_data["labels"] == "bug"
         assert json_data["milestone"] == "v1.0"
 
+    def test_editor_fails_before_prompting_for_title(self, runner, mock_client, mock_repo):
+        result = runner.invoke(main, ["issue", "create", "--editor"], input="Should not be consumed\n")
+        assert result.exit_code != 0
+        assert (
+            "gh-compatible command/flag 'issue create --editor' is recognized but not implemented yet." in result.output
+        )
+        assert "Title" not in result.output
+        mock_client.post.assert_not_called()
+
 
 class TestIssueClose:
     def test_default(self, runner, mock_client, mock_repo):

--- a/tests/unit/commands/test_issue_adapter_boundary.py
+++ b/tests/unit/commands/test_issue_adapter_boundary.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from gitcode_cli.cli import main
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_repo(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("gitcode_cli.commands.issue.resolve_repo", lambda x=None: ("owner", "repo"))
+
+
+@pytest.fixture
+def mock_app_client(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    client = MagicMock()
+    monkeypatch.setattr("gitcode_cli.context.AppContext.client", lambda self: client)
+    return client
+
+
+class TestIssueCommandAdapterBoundary:
+    def test_issue_list_delegates_to_adapter(
+        self, runner: CliRunner, mock_repo: None, mock_app_client: MagicMock
+    ) -> None:
+        adapter = MagicMock()
+        adapter.list_issues.return_value = [{"number": "1", "state": "open", "title": "First"}]
+
+        issue_service_ctor = MagicMock()
+        issue_adapter_ctor = MagicMock(return_value=adapter)
+
+        with (
+            pytest.MonkeyPatch.context() as mp,
+        ):
+            mp.setattr("gitcode_cli.commands.issue.IssueService", issue_service_ctor)
+            mp.setattr("gitcode_cli.commands.issue.IssueAdapter", issue_adapter_ctor)
+            result = runner.invoke(
+                main,
+                ["issue", "list", "-s", "open", "-l", "bug", "-A", "alice", "-L", "5"],
+            )
+
+        assert result.exit_code == 0
+        issue_service_ctor.assert_called_once_with(mock_app_client)
+        issue_adapter_ctor.assert_called_once_with(issue_service_ctor.return_value)
+        adapter.list_issues.assert_called_once_with(
+            "owner",
+            "repo",
+            state="open",
+            labels=("bug",),
+            author="alice",
+            assignee=None,
+            milestone=None,
+            mention=None,
+            search=None,
+            limit=5,
+        )
+
+    def test_issue_create_delegates_to_adapter(
+        self, runner: CliRunner, mock_repo: None, mock_app_client: MagicMock
+    ) -> None:
+        adapter = MagicMock()
+        adapter.create_issue.return_value = {"html_url": "https://example.com/issues/42"}
+
+        issue_service_ctor = MagicMock()
+        issue_adapter_ctor = MagicMock(return_value=adapter)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("gitcode_cli.commands.issue.IssueService", issue_service_ctor)
+            mp.setattr("gitcode_cli.commands.issue.IssueAdapter", issue_adapter_ctor)
+            result = runner.invoke(
+                main,
+                ["issue", "create", "-t", "Bug", "-b", "Body", "-l", "bug", "-m", "v1"],
+            )
+
+        assert result.exit_code == 0
+        issue_service_ctor.assert_called_once_with(mock_app_client)
+        issue_adapter_ctor.assert_called_once_with(issue_service_ctor.return_value)
+        adapter.create_issue.assert_called_once_with(
+            "owner",
+            "repo",
+            title="Bug",
+            body="Body",
+            assignee=None,
+            labels=("bug",),
+            milestone="v1",
+        )
+
+    def test_issue_close_delegates_to_adapter(
+        self, runner: CliRunner, mock_repo: None, mock_app_client: MagicMock
+    ) -> None:
+        adapter = MagicMock()
+        adapter.close_issue.return_value = type("Result", (), {"message": "closed", "item": {"number": "42"}})()
+
+        issue_service_ctor = MagicMock()
+        issue_adapter_ctor = MagicMock(return_value=adapter)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("gitcode_cli.commands.issue.IssueService", issue_service_ctor)
+            mp.setattr("gitcode_cli.commands.issue.IssueAdapter", issue_adapter_ctor)
+            result = runner.invoke(
+                main,
+                ["issue", "close", "42", "-c", "done", "-r", "completed"],
+            )
+
+        assert result.exit_code == 0
+        issue_service_ctor.assert_called_once_with(mock_app_client)
+        issue_adapter_ctor.assert_called_once_with(issue_service_ctor.return_value)
+        adapter.close_issue.assert_called_once_with(
+            "owner",
+            "repo",
+            "42",
+            comment="done",
+            reason="completed",
+        )

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -262,14 +262,15 @@ class TestPrCreate:
         assert mock_body.call_args == call(body=None, body_file=None, editor=False)
         assert mock_client.post.call_args.kwargs["json"]["body"] == "resolved body"
 
-    def test_pr_create_editor_uses_body_helper_with_editor(self, runner, mock_client, mock_repo):
+    def test_pr_create_editor_is_recognized_but_pending(self, runner, mock_client, mock_repo):
         with patch("gitcode_cli.commands.pr.get_body_from_options", return_value="resolved body") as mock_body:
             result = runner.invoke(
                 main, ["pr", "create", "--title", "Test", "--head", "feature", "--base", "main", "--editor"]
             )
-        assert result.exit_code == 0
-        assert mock_body.call_args == call(body=None, body_file=None, editor=True)
-        assert mock_client.post.call_args.kwargs["json"]["body"] == "resolved body"
+        assert result.exit_code != 0
+        assert "gh-compatible command/flag 'pr create --editor' is recognized but not implemented yet." in result.output
+        mock_body.assert_not_called()
+        mock_client.post.assert_not_called()
 
     def test_pr_create_dry_run_prints_normalized_payload_without_post(self, runner, mock_client, mock_repo):
         result = runner.invoke(

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -262,15 +262,14 @@ class TestPrCreate:
         assert mock_body.call_args == call(body=None, body_file=None, editor=False)
         assert mock_client.post.call_args.kwargs["json"]["body"] == "resolved body"
 
-    def test_pr_create_editor_is_recognized_but_pending(self, runner, mock_client, mock_repo):
+    def test_pr_create_editor_uses_body_helper_with_editor(self, runner, mock_client, mock_repo):
         with patch("gitcode_cli.commands.pr.get_body_from_options", return_value="resolved body") as mock_body:
             result = runner.invoke(
                 main, ["pr", "create", "--title", "Test", "--head", "feature", "--base", "main", "--editor"]
             )
-        assert result.exit_code != 0
-        assert "gh-compatible command/flag 'pr create --editor' is recognized but not implemented yet." in result.output
-        mock_body.assert_not_called()
-        mock_client.post.assert_not_called()
+        assert result.exit_code == 0
+        assert mock_body.call_args == call(body=None, body_file=None, editor=True)
+        assert mock_client.post.call_args.kwargs["json"]["body"] == "resolved body"
 
     def test_pr_create_dry_run_prints_normalized_payload_without_post(self, runner, mock_client, mock_repo):
         result = runner.invoke(

--- a/tests/unit/commands/test_pr_adapter_boundary.py
+++ b/tests/unit/commands/test_pr_adapter_boundary.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from gitcode_cli.cli import main
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_repo(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("gitcode_cli.commands.pr.resolve_repo", lambda x=None: ("owner", "repo"))
+
+
+@pytest.fixture
+def mock_app_client(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    client = MagicMock()
+    monkeypatch.setattr("gitcode_cli.context.AppContext.client", lambda self: client)
+    return client
+
+
+class TestPrCommandAdapterBoundary:
+    def test_pr_list_delegates_to_adapter(self, runner: CliRunner, mock_repo: None, mock_app_client: MagicMock) -> None:
+        adapter = MagicMock()
+        adapter.list_prs.return_value = [{"number": 1, "state": "open", "title": "First PR"}]
+
+        pull_service_ctor = MagicMock()
+        pull_adapter_ctor = MagicMock(return_value=adapter)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("gitcode_cli.commands.pr.PullRequestService", pull_service_ctor)
+            mp.setattr("gitcode_cli.commands.pr.PullRequestAdapter", pull_adapter_ctor)
+            result = runner.invoke(
+                main, ["pr", "list", "-s", "open", "-A", "alice", "-B", "main", "-l", "bug", "-L", "5"]
+            )
+
+        assert result.exit_code == 0
+        pull_service_ctor.assert_called_once_with(mock_app_client)
+        pull_adapter_ctor.assert_called_once_with(pull_service_ctor.return_value)
+        adapter.list_prs.assert_called_once_with(
+            "owner",
+            "repo",
+            state="open",
+            author="alice",
+            base="main",
+            assignee=None,
+            draft=None,
+            head=None,
+            labels=("bug",),
+            search=None,
+            limit=5,
+        )
+
+    def test_pr_create_delegates_to_adapter(
+        self, runner: CliRunner, mock_repo: None, mock_app_client: MagicMock
+    ) -> None:
+        adapter = MagicMock()
+        adapter.create_pr.return_value = type("Result", (), {"item": {"html_url": "https://example.com/pulls/42"}})()
+
+        pull_service_ctor = MagicMock()
+        pull_adapter_ctor = MagicMock(return_value=adapter)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("gitcode_cli.commands.pr.PullRequestService", pull_service_ctor)
+            mp.setattr("gitcode_cli.commands.pr.PullRequestAdapter", pull_adapter_ctor)
+            result = runner.invoke(
+                main,
+                [
+                    "pr",
+                    "create",
+                    "--title",
+                    "Feature",
+                    "--body",
+                    "Body",
+                    "--base",
+                    "main",
+                    "--head",
+                    "feature",
+                    "-l",
+                    "bug",
+                    "-r",
+                    "alice",
+                    "-a",
+                    "bob",
+                ],
+            )
+
+        assert result.exit_code == 0
+        pull_service_ctor.assert_called_once_with(mock_app_client)
+        pull_adapter_ctor.assert_called_once_with(pull_service_ctor.return_value)
+        adapter.create_pr.assert_called_once_with(
+            "owner",
+            "repo",
+            title="Feature",
+            body="Body",
+            base="main",
+            head="feature",
+            draft=False,
+            milestone=None,
+            labels=("bug",),
+            reviewers=("alice",),
+            assignees=("bob",),
+            dry_run=False,
+        )
+
+    def test_pr_review_delegates_to_adapter(
+        self, runner: CliRunner, mock_repo: None, mock_app_client: MagicMock
+    ) -> None:
+        adapter = MagicMock()
+        adapter.review_pr.return_value = type(
+            "Result", (), {"item": {"state": "APPROVED"}, "degraded": False, "message": None}
+        )()
+
+        pull_service_ctor = MagicMock()
+        pull_adapter_ctor = MagicMock(return_value=adapter)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("gitcode_cli.commands.pr.PullRequestService", pull_service_ctor)
+            mp.setattr("gitcode_cli.commands.pr.PullRequestAdapter", pull_adapter_ctor)
+            result = runner.invoke(
+                main,
+                ["pr", "review", "42", "--approve", "--body", "LGTM"],
+            )
+
+        assert result.exit_code == 0
+        pull_service_ctor.assert_called_once_with(mock_app_client)
+        pull_adapter_ctor.assert_called_once_with(pull_service_ctor.return_value)
+        adapter.review_pr.assert_called_once_with(
+            "owner",
+            "repo",
+            42,
+            approve=True,
+            body="LGTM",
+            comment=False,
+            request_changes=False,
+            force=False,
+        )


### PR DESCRIPTION
## Description

Add explicit layered test coverage for issue #64 by introducing:
- command-to-adapter boundary tests for `issue` and `pr`
- service-to-doc contract tests against extracted GitCode API schemas
- a short `tests/README.md` explaining the test layering strategy
- `gh --help`-derived CLI compatibility assertions for issue/PR commands
- Click-layer acceptance for additional gh-compatible flags that currently return clear pending errors
- a follow-up tracking issue for unimplemented accepted flags: #68

## Related Issue

Fixes #64

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Full test suite passes (`conda run -n gitcode-cli pytest tests`)
- [x] Type check passes (`basedpyright` via pre-commit)
- [x] Lint passes (`ruff` via pre-commit)
- [x] Format passes (`ruff-format` via pre-commit)
- [x] Test coverage remains >= 90%

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide