### PR TITLE
fix gh-compatible pending command flows

### DIFF
--- a/src/gitcode_cli/adapters/capabilities.py
+++ b/src/gitcode_cli/adapters/capabilities.py
@@ -3,13 +3,20 @@ from __future__ import annotations
 import click
 
 CAPABILITY_MESSAGES = {
-    "PR_REVIEW_REQUEST_CHANGES": (
-        "GitCode review API does not support request-changes reviews; the pull request comment was posted instead."
+    "ISSUE_COMMENT_LAST_NOT_FOUND": "No editable issue comment from the current user was found.",
+    "ISSUE_COMMENT_OWNERSHIP_UNVERIFIABLE": (
+        "Unable to verify the current user's issue comments on GitCode; refusing to edit or delete comments safely."
     ),
+    "ISSUE_CREATE_IF_NONE_REQUIRES_EDIT_LAST": "--create-if-none can only be used together with --edit-last.",
     "ISSUE_DELETE": "GitCode API does not support deleting issues.",
     "ISSUE_DEVELOP_BASE": "--base and --name are not supported by 'gc issue develop'",
     "ISSUE_DEVELOP_NAME": "--base and --name are not supported by 'gc issue develop'",
     "ISSUE_STATUS_GH_SEMANTICS": "GitCode-limited approximation of gh issue status",
+    "PR_MERGE_AUTHOR_EMAIL": "GitCode merge API does not support --author-email.",
+    "PR_MERGE_AUTO": "GitCode merge API does not support --auto.",
+    "PR_REVIEW_REQUEST_CHANGES": (
+        "GitCode review API does not support request-changes reviews; the pull request comment was posted instead."
+    ),
     "PR_STATUS_GH_SEMANTICS": ("GitCode API approximation -- user-specific filtering is not available"),
 }
 

--- a/src/gitcode_cli/adapters/issues.py
+++ b/src/gitcode_cli/adapters/issues.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..services import IssueService
+import click
+
+from ..errors import APIError
+from ..services import IssueService, UserService
 from .base import AdapterActionResult
 from .capabilities import capability_message, unsupported
 
@@ -32,9 +35,26 @@ def _extract_label_names(issue: dict[str, Any] | None) -> list[str]:
     return names
 
 
+def _extract_login(data: dict[str, Any] | None) -> str | None:
+    if not isinstance(data, dict):
+        return None
+    for key in ("login", "username", "name"):
+        value = data.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    user = data.get("user")
+    if isinstance(user, dict):
+        return _extract_login(user)
+    author = data.get("author")
+    if isinstance(author, dict):
+        return _extract_login(author)
+    return None
+
+
 class IssueAdapter:
-    def __init__(self, service: IssueService):
+    def __init__(self, service: IssueService, user_service: UserService | None = None):
         self.service = service
+        self.user_service = user_service
 
     def list_issues(
         self,
@@ -111,6 +131,48 @@ class IssueAdapter:
 
     def comment_issue(self, owner: str, repo: str, number: str, *, body: str) -> dict[str, Any] | None:
         return self.service.comment(owner, repo, number, body)
+
+    def manage_comment_history(
+        self,
+        owner: str,
+        repo: str,
+        number: str,
+        *,
+        body: str | None,
+        delete_last: bool,
+        create_if_none: bool,
+    ) -> AdapterActionResult:
+        comment = self._find_last_owned_comment(owner, repo, number)
+        if delete_last:
+            if comment is None:
+                raise click.ClickException(capability_message("ISSUE_COMMENT_LAST_NOT_FOUND"))
+            self.service.delete_comment(owner, repo, comment["id"])
+            return AdapterActionResult(item=comment, message="deleted")
+        if comment is None:
+            if create_if_none:
+                item = self.service.comment(owner, repo, number, body or "")
+                return AdapterActionResult(item=item, message="created")
+            raise click.ClickException(capability_message("ISSUE_COMMENT_LAST_NOT_FOUND"))
+        item = self.service.update_comment(owner, repo, comment["id"], body or "")
+        return AdapterActionResult(item=item, message="edited")
+
+    def _find_last_owned_comment(self, owner: str, repo: str, number: str) -> dict[str, Any] | None:
+        if self.user_service is None:
+            raise click.ClickException(capability_message("ISSUE_COMMENT_OWNERSHIP_UNVERIFIABLE"))
+        try:
+            current_user = self.user_service.current()
+        except APIError as exc:
+            raise click.ClickException(capability_message("ISSUE_COMMENT_OWNERSHIP_UNVERIFIABLE")) from exc
+        current_login = _extract_login(current_user)
+        if not current_login:
+            raise click.ClickException(capability_message("ISSUE_COMMENT_OWNERSHIP_UNVERIFIABLE"))
+        comments = self.service.list_comments(owner, repo, number) or []
+        for comment in reversed(comments):
+            if not isinstance(comment, dict):
+                continue
+            if _extract_login(comment) == current_login:
+                return comment
+        return None
 
     def reopen_issue(self, owner: str, repo: str, number: str) -> AdapterActionResult:
         current = self.service.get(owner, repo, number)

--- a/src/gitcode_cli/adapters/pulls.py
+++ b/src/gitcode_cli/adapters/pulls.py
@@ -79,6 +79,25 @@ class PullRequestAdapter:
             return AdapterActionResult(item={k: v for k, v in payload.items() if v is not None})
         return AdapterActionResult(item=self.service.create(owner, repo, **payload))
 
+    def merge_pr(
+        self,
+        owner: str,
+        repo: str,
+        number: int,
+        *,
+        merge_method: str,
+        body: str | None,
+        subject: str | None,
+        admin: bool,
+    ) -> dict[str, Any] | None:
+        payload = {
+            "merge_method": merge_method,
+            "description": body,
+            "title": subject,
+            "force_merge": True if admin else None,
+        }
+        return self.service.merge(owner, repo, number, **payload)
+
     def review_pr(
         self,
         owner: str,
@@ -91,8 +110,6 @@ class PullRequestAdapter:
         request_changes: bool,
         force: bool,
     ) -> AdapterActionResult:
-        # GitCode's review endpoint is approval-only and does not accept a review body;
-        # comment-style reviews must go through the PR comments endpoint instead.
         if comment:
             item = self.service.comment(owner, repo, number, body=body or "")
             return AdapterActionResult(item=item)

--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import click
 
 from ..adapters import IssueAdapter
+from ..adapters.capabilities import capability_message
 from ..cli_compat import get_body_from_options
 from ..formatters import format_issue_detail, format_issue_list, output_result
 from ..repo import resolve_repo
-from ..services import IssueService
+from ..services import IssueService, UserService
 from ..utils import (
     open_in_browser,
     prompt_if_missing,
@@ -25,6 +26,61 @@ def _echo_issue_summary(items: list[dict]) -> None:
 
 def _pending_gh_compat(name: str) -> None:
     raise click.ClickException(f"gh-compatible command/flag '{name}' is recognized but not implemented yet.")
+
+
+def _resolve_issue_target(app, repo_name: str | None, identifier: str) -> tuple[str, str, str, str | None]:
+    url_owner, url_repo, number = resolve_issue_arg(identifier)
+    if url_owner:
+        assert url_repo is not None
+        return url_owner, url_repo, number, identifier
+    owner, repo = resolve_repo(repo_name or app.repo)
+    return owner, repo, require_issue_number(identifier), None
+
+
+def _validate_issue_comment_history_flags(
+    *, create_if_none: bool, delete_last: bool, edit_last: bool, yes: bool
+) -> None:
+    if create_if_none and not edit_last:
+        raise click.UsageError(capability_message("ISSUE_CREATE_IF_NONE_REQUIRES_EDIT_LAST"))
+    if create_if_none and delete_last:
+        raise click.UsageError(capability_message("ISSUE_CREATE_IF_NONE_REQUIRES_EDIT_LAST"))
+    if yes and not delete_last:
+        raise click.UsageError("--yes can only be used together with --delete-last.")
+    if edit_last and delete_last:
+        raise click.UsageError("Specify only one of --edit-last or --delete-last.")
+
+
+def _handle_issue_comment_history(
+    *,
+    adapter: IssueAdapter,
+    owner: str,
+    repo: str,
+    number: str,
+    body: str | None,
+    edit_last: bool,
+    delete_last: bool,
+    create_if_none: bool,
+    yes: bool,
+) -> None:
+    if edit_last:
+        body = prompt_if_missing(body, "Comment")
+    if delete_last and not yes and not click.confirm("Delete your last issue comment?", default=False):
+        raise click.ClickException("Aborted.")
+    result = adapter.manage_comment_history(
+        owner,
+        repo,
+        number,
+        body=body,
+        delete_last=delete_last,
+        create_if_none=create_if_none,
+    )
+    if result.message == "deleted":
+        safe_echo(f"Deleted last comment on issue #{number}")
+        return
+    if result.message == "created":
+        safe_echo(result.item.get("html_url") or f"Commented on issue #{number}")
+        return
+    safe_echo(result.item.get("html_url") or f"Edited last comment on issue #{number}")
 
 
 @click.group("issue")
@@ -193,12 +249,12 @@ def issue_create(
     if web:
         open_in_browser(f"https://gitcode.com/{owner}/{repo}/issues/new")
         return
-    if editor:
-        _pending_gh_compat("issue create --editor")
     title = prompt_if_missing(title, "Title")
     if len(title) > 255:
         raise click.ClickException("title must be 255 characters or fewer")
-    body = get_body_from_options(body=body, body_file=body_file, editor=False)
+    body = get_body_from_options(body=body, body_file=body_file, editor=editor)
+    if editor and body is None:
+        raise click.ClickException("Editor was closed without saving an issue body.")
     service = IssueService(app.client())
     adapter = IssueAdapter(service)
     item = adapter.create_issue(
@@ -241,6 +297,7 @@ def issue_close(
         owner, repo = url_owner, url_repo
     else:
         owner, repo = resolve_repo(repo_name or app.repo)
+        number = require_issue_number(identifier)
     if duplicate_of is not None:
         _pending_gh_compat("issue close --duplicate-of")
     service = IssueService(app.client())
@@ -281,24 +338,40 @@ def issue_comment(
     yes: bool,
 ) -> None:
     app = ctx.obj["app"]
-    url_owner, url_repo, number = resolve_issue_arg(identifier)
-    if url_owner:
-        assert url_repo is not None
-        owner, repo = url_owner, url_repo
-    else:
-        owner, repo = resolve_repo(repo_name or app.repo)
+    owner, repo, number, target_url = _resolve_issue_target(app, repo_name, identifier)
     if web:
-        target_url = identifier if url_owner else f"https://gitcode.com/{owner}/{repo}/issues/{number}"
-        open_in_browser(target_url)
+        open_in_browser(target_url or f"https://gitcode.com/{owner}/{repo}/issues/{number}")
         return
-    if create_if_none or delete_last or edit_last or yes:
-        _pending_gh_compat("issue comment history-management flags")
+
+    _validate_issue_comment_history_flags(
+        create_if_none=create_if_none,
+        delete_last=delete_last,
+        edit_last=edit_last,
+        yes=yes,
+    )
+    history_mode = edit_last or delete_last
     body = get_body_from_options(body=body, body_file=body_file, editor=editor)
     if editor and body is None:
         raise click.ClickException("Editor was closed without saving a comment.")
-    body = prompt_if_missing(body, "Comment")
+
     service = IssueService(app.client())
-    adapter = IssueAdapter(service)
+    adapter = IssueAdapter(service, UserService(app.client()))
+
+    if history_mode:
+        _handle_issue_comment_history(
+            adapter=adapter,
+            owner=owner,
+            repo=repo,
+            number=number,
+            body=body,
+            edit_last=edit_last,
+            delete_last=delete_last,
+            create_if_none=create_if_none,
+            yes=yes,
+        )
+        return
+
+    body = prompt_if_missing(body, "Comment")
     item = adapter.comment_issue(owner, repo, number, body=body)
     safe_echo(item.get("html_url") or f"Commented on issue #{number}")
 
@@ -315,6 +388,7 @@ def issue_reopen(ctx: click.Context, repo_name: str | None, identifier: str) -> 
         owner, repo = url_owner, url_repo
     else:
         owner, repo = resolve_repo(repo_name or app.repo)
+        number = require_issue_number(identifier)
     service = IssueService(app.client())
     adapter = IssueAdapter(service)
     result = adapter.reopen_issue(owner, repo, number)
@@ -354,6 +428,7 @@ def issue_edit(
         owner, repo = url_owner, url_repo
     else:
         owner, repo = resolve_repo(repo_name or app.repo)
+        number = require_issue_number(identifier)
     body = get_body_from_options(body=body, body_file=body_file, editor=False)
     if not any(
         [
@@ -394,6 +469,7 @@ def issue_delete(ctx: click.Context, repo_name: str | None, identifier: str) -> 
         owner, repo = url_owner, url_repo
     else:
         owner, repo = resolve_repo(repo_name or app.repo)
+        number = require_issue_number(identifier)
     service = IssueService(app.client())
     adapter = IssueAdapter(service)
     adapter.delete_issue(owner, repo, number)
@@ -434,6 +510,7 @@ def issue_develop(
         owner, repo = url_owner, url_repo
     else:
         owner, repo = resolve_repo(repo_name or app.repo)
+        number = require_issue_number(identifier)
     service = IssueService(app.client())
     adapter = IssueAdapter(service)
     result = adapter.develop(owner, repo, number, base=base, name=name)

--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -35,6 +35,249 @@ def pr_group() -> None:
     pass
 
 
+@pr_group.command("merge")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.argument("identifier", required=False)
+@click.option("-m", "--merge", is_flag=True, help="Merge the pull request.")
+@click.option("-s", "--squash", is_flag=True, help="Squash the pull request.")
+@click.option("-r", "--rebase", is_flag=True, help="Rebase the pull request.")
+@click.option("-d", "--delete-branch", is_flag=True, help="Delete the remote branch after merge.")
+@click.option("-b", "--body")
+@click.option("-F", "--body-file")
+@click.option("-t", "--subject")
+@click.option("-A", "--author-email")
+@click.option("--auto", is_flag=True)
+@click.option("--admin", is_flag=True)
+@click.pass_context
+def pr_merge(
+    ctx: click.Context,
+    repo_name: str | None,
+    identifier: str | None,
+    merge: bool,
+    squash: bool,
+    rebase: bool,
+    delete_branch: bool,
+    body: str | None,
+    body_file: str | None,
+    subject: str | None,
+    author_email: str | None,
+    auto: bool,
+    admin: bool,
+) -> None:
+    app = ctx.obj["app"]
+    owner, repo = resolve_repo(repo_name or app.repo)
+    if author_email is not None:
+        raise click.ClickException("GitCode merge API does not support --author-email.")
+    if auto:
+        raise click.ClickException("GitCode merge API does not support --auto.")
+    service = PullRequestService(app.client())
+    resolved_identifier = resolve_pr_identifier_or_current_branch(identifier)
+    owner, repo, number = resolve_pr_arg(resolved_identifier, owner, repo, service)
+    number = int(number)
+    selected = [merge, squash, rebase]
+    if sum(selected) > 1:
+        raise click.UsageError("-m, -s, and -r are mutually exclusive. Specify only one merge method.")
+    merge_method = ["merge", "squash", "rebase"][selected.index(True)] if any(selected) else "merge"
+    body = get_body_from_options(body=body, body_file=body_file, editor=False)
+    pr_item = service.get(owner, repo, number)
+    adapter = PullRequestAdapter(service)
+    item = adapter.merge_pr(owner, repo, number, merge_method=merge_method, body=body, subject=subject, admin=admin)
+    safe_echo(item["message"])
+    if delete_branch:
+        try:
+            branch = pr_item.get("head", {}).get("ref")
+            if branch:
+                subprocess.run(["git", "push", "origin", "--delete", branch], check=True)
+                safe_echo(f"Deleted remote branch {branch}")
+            else:
+                safe_echo("Warning: could not determine branch to delete.", err=True)
+        except Exception as exc:
+            safe_echo(f"Warning: could not delete remote branch: {exc}", err=True)
+
+
+@pr_group.command("comment")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.argument("identifier", required=False)
+@click.option("-b", "--body")
+@click.option("-F", "--body-file")
+@click.option("-e", "--editor", is_flag=True)
+@click.option("-w", "--web", is_flag=True, help="Open the pull request in the web browser.")
+@click.option("--path")
+@click.option("--position", type=int)
+@click.pass_context
+def pr_comment(
+    ctx: click.Context,
+    repo_name: str | None,
+    identifier: str | None,
+    body: str | None,
+    body_file: str | None,
+    editor: bool,
+    web: bool,
+    path: str | None,
+    position: int | None,
+) -> None:
+    app = ctx.obj["app"]
+    owner, repo = resolve_repo(repo_name or app.repo)
+    service = PullRequestService(app.client())
+    resolved_identifier = resolve_pr_identifier_or_current_branch(identifier)
+    owner, repo, number = resolve_pr_arg(resolved_identifier, owner, repo, service)
+    number = int(number)
+    if web:
+        pr_item = service.get(owner, repo, number)
+        open_in_browser(pr_item["html_url"])
+        return
+    body = get_body_from_options(body=body, body_file=body_file, editor=editor)
+    body = prompt_if_missing(body, "Body")
+    item = service.comment(owner, repo, number, body=body, path=path, position=position)
+    safe_echo(str(item["id"]))
+
+
+@pr_group.command("review")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.argument("identifier", required=False)
+@click.option("-a", "--approve", is_flag=True, help="Approve the pull request. GitCode maps this to its review API.")
+@click.option("-b", "--body")
+@click.option("-F", "--body-file")
+@click.option("-c", "--comment", is_flag=True, help="Leave a review comment.")
+@click.option("-r", "--request-changes", is_flag=True, help="Request changes. Downgrades to a PR comment on GitCode.")
+@click.option("--force", is_flag=True, help="Force review handling when supported by GitCode.")
+@click.pass_context
+def pr_review(
+    ctx: click.Context,
+    repo_name: str | None,
+    identifier: str | None,
+    approve: bool,
+    body: str | None,
+    body_file: str | None,
+    comment: bool,
+    request_changes: bool,
+    force: bool,
+) -> None:
+    app = ctx.obj["app"]
+    owner, repo = resolve_repo(repo_name or app.repo)
+    service = PullRequestService(app.client())
+    resolved_identifier = resolve_pr_identifier_or_current_branch(identifier)
+    owner, repo, number = resolve_pr_arg(resolved_identifier, owner, repo, service)
+    number = int(number)
+    body = get_body_from_options(body=body, body_file=body_file, editor=False)
+    selected_modes = [approve, comment, request_changes]
+    if sum(1 for selected in selected_modes if selected) != 1:
+        raise click.ClickException("Specify exactly one of --approve, --comment, or --request-changes.")
+    if (comment or request_changes) and not body:
+        raise click.ClickException("Body is required when using --comment or --request-changes.")
+
+    adapter = PullRequestAdapter(service)
+    result = adapter.review_pr(
+        owner,
+        repo,
+        number,
+        approve=approve,
+        body=body,
+        comment=comment,
+        request_changes=request_changes,
+        force=force,
+    )
+    if result.degraded:
+        safe_echo(f"Posted pull request comment {result.item['id']}")
+        raise click.ClickException(result.message or "degraded review operation")
+    if comment:
+        safe_echo(f"Posted pull request comment {result.item['id']}")
+        return
+    safe_echo(f"Reviewed pull request #{number}")
+
+
+@pr_group.command("reopen")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.argument("identifier", required=False)
+@click.pass_context
+def pr_reopen(ctx: click.Context, repo_name: str | None, identifier: str | None) -> None:
+    app = ctx.obj["app"]
+    owner, repo = resolve_repo(repo_name or app.repo)
+    service = PullRequestService(app.client())
+    resolved_identifier = resolve_pr_identifier_or_current_branch(identifier)
+    owner, repo, number = resolve_pr_arg(resolved_identifier, owner, repo, service)
+    number = int(number)
+    item = service.update(owner, repo, number, state="open")
+    safe_echo(f"Reopened pull request #{safe_number(item, number)}")
+
+
+@pr_group.command("edit")
+@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.argument("identifier", required=False)
+@click.option("-t", "--title")
+@click.option("-b", "--body")
+@click.option("-F", "--body-file")
+@click.option("-B", "--base")
+@click.option("-a", "--add-assignee")
+@click.option("-l", "--add-label")
+@click.option("-r", "--add-reviewer")
+@click.option("--remove-assignee")
+@click.option("--remove-label")
+@click.option("--remove-reviewer")
+@click.option("-m", "--milestone")
+@click.option("--remove-milestone", is_flag=True, help="Remove the milestone from the pull request.")
+@click.pass_context
+def pr_edit(
+    ctx: click.Context,
+    repo_name: str | None,
+    identifier: str | None,
+    title: str | None,
+    body: str | None,
+    body_file: str | None,
+    base: str | None,
+    add_assignee: str | None,
+    add_label: str | None,
+    add_reviewer: str | None,
+    remove_assignee: str | None,
+    remove_label: str | None,
+    remove_reviewer: str | None,
+    milestone: str | None,
+    remove_milestone: bool,
+) -> None:
+    app = ctx.obj["app"]
+    owner, repo = resolve_repo(repo_name or app.repo)
+    service = PullRequestService(app.client())
+    resolved_identifier = resolve_pr_identifier_or_current_branch(identifier)
+    owner, repo, number = resolve_pr_arg(resolved_identifier, owner, repo, service)
+    number = int(number)
+    if body_file:
+        body = read_body_file(body_file)
+    if not any(
+        [
+            title is not None,
+            body is not None,
+            base is not None,
+            add_assignee is not None,
+            add_label is not None,
+            add_reviewer is not None,
+            remove_assignee is not None,
+            remove_label is not None,
+            remove_reviewer is not None,
+            milestone is not None,
+            remove_milestone,
+        ]
+    ):
+        raise click.UsageError("must specify at least one field to edit")
+    adapter = PullRequestAdapter(service)
+    item = adapter.edit_pr(
+        owner,
+        repo,
+        number,
+        title=title,
+        body=body,
+        base=base,
+        add_assignee=add_assignee,
+        add_label=add_label,
+        add_reviewer=add_reviewer,
+        remove_assignee=remove_assignee,
+        remove_label=remove_label,
+        remove_reviewer=remove_reviewer,
+        milestone=milestone,
+        remove_milestone=remove_milestone,
+    )
+    safe_echo(f"Edited pull request #{safe_number(item, number)}")
+
+
 @pr_group.command("list")
 @click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
 @click.option("-s", "--state")
@@ -298,248 +541,6 @@ def pr_close(
         except Exception as exc:
             safe_echo(f"Warning: could not delete remote branch: {exc}", err=True)
     safe_echo(f"Closed pull request #{safe_number(item, number)}")
-
-
-@pr_group.command("merge")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
-@click.argument("identifier", required=False)
-@click.option("-m", "--merge", is_flag=True, help="Merge the pull request.")
-@click.option("-s", "--squash", is_flag=True, help="Squash the pull request.")
-@click.option("-r", "--rebase", is_flag=True, help="Rebase the pull request.")
-@click.option("-d", "--delete-branch", is_flag=True, help="Delete the remote branch after merge.")
-@click.option("-b", "--body")
-@click.option("-F", "--body-file")
-@click.option("-t", "--subject")
-@click.option("-A", "--author-email")
-@click.option("--auto", is_flag=True)
-@click.option("--admin", is_flag=True)
-@click.pass_context
-def pr_merge(
-    ctx: click.Context,
-    repo_name: str | None,
-    identifier: str | None,
-    merge: bool,
-    squash: bool,
-    rebase: bool,
-    delete_branch: bool,
-    body: str | None,
-    body_file: str | None,
-    subject: str | None,
-    author_email: str | None,
-    auto: bool,
-    admin: bool,
-) -> None:
-    app = ctx.obj["app"]
-    owner, repo = resolve_repo(repo_name or app.repo)
-    if any(value is not None for value in (body, body_file, subject, author_email)) or auto or admin:
-        _pending_gh_compat("pr merge advanced gh flags")
-    service = PullRequestService(app.client())
-    resolved_identifier = resolve_pr_identifier_or_current_branch(identifier)
-    owner, repo, number = resolve_pr_arg(resolved_identifier, owner, repo, service)
-    number = int(number)
-    selected = [merge, squash, rebase]
-    if sum(selected) > 1:
-        raise click.UsageError("-m, -s, and -r are mutually exclusive. Specify only one merge method.")
-    merge_method = ["merge", "squash", "rebase"][selected.index(True)] if any(selected) else "merge"
-    pr_item = service.get(owner, repo, number)
-    item = service.merge(owner, repo, number, merge_method=merge_method)
-    safe_echo(item["message"])
-    if delete_branch:
-        try:
-            branch = pr_item.get("head", {}).get("ref")
-            if branch:
-                subprocess.run(["git", "push", "origin", "--delete", branch], check=True)
-                safe_echo(f"Deleted remote branch {branch}")
-            else:
-                safe_echo("Warning: could not determine branch to delete.", err=True)
-        except Exception as exc:
-            safe_echo(f"Warning: could not delete remote branch: {exc}", err=True)
-
-
-@pr_group.command("comment")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
-@click.argument("identifier", required=False)
-@click.option("-b", "--body")
-@click.option("-F", "--body-file")
-@click.option("-e", "--editor", is_flag=True)
-@click.option("-w", "--web", is_flag=True, help="Open the pull request in the web browser.")
-@click.option("--path")
-@click.option("--position", type=int)
-@click.pass_context
-def pr_comment(
-    ctx: click.Context,
-    repo_name: str | None,
-    identifier: str | None,
-    body: str | None,
-    body_file: str | None,
-    editor: bool,
-    web: bool,
-    path: str | None,
-    position: int | None,
-) -> None:
-    app = ctx.obj["app"]
-    owner, repo = resolve_repo(repo_name or app.repo)
-    service = PullRequestService(app.client())
-    resolved_identifier = resolve_pr_identifier_or_current_branch(identifier)
-    owner, repo, number = resolve_pr_arg(resolved_identifier, owner, repo, service)
-    number = int(number)
-    if web:
-        pr_item = service.get(owner, repo, number)
-        open_in_browser(pr_item["html_url"])
-        return
-    body = get_body_from_options(body=body, body_file=body_file, editor=editor)
-    body = prompt_if_missing(body, "Body")
-    item = service.comment(owner, repo, number, body=body, path=path, position=position)
-    safe_echo(str(item["id"]))
-
-
-@pr_group.command("review")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
-@click.argument("identifier", required=False)
-@click.option("-a", "--approve", is_flag=True, help="Approve the pull request. GitCode maps this to its review API.")
-@click.option("-b", "--body")
-@click.option("-F", "--body-file")
-@click.option("-c", "--comment", is_flag=True, help="Leave a review comment.")
-@click.option("-r", "--request-changes", is_flag=True, help="Request changes. Downgrades to a PR comment on GitCode.")
-@click.option("--force", is_flag=True, help="Force review handling when supported by GitCode.")
-@click.pass_context
-def pr_review(
-    ctx: click.Context,
-    repo_name: str | None,
-    identifier: str | None,
-    approve: bool,
-    body: str | None,
-    body_file: str | None,
-    comment: bool,
-    request_changes: bool,
-    force: bool,
-) -> None:
-    app = ctx.obj["app"]
-    owner, repo = resolve_repo(repo_name or app.repo)
-    service = PullRequestService(app.client())
-    resolved_identifier = resolve_pr_identifier_or_current_branch(identifier)
-    owner, repo, number = resolve_pr_arg(resolved_identifier, owner, repo, service)
-    number = int(number)
-
-    if body_file is not None:
-        _pending_gh_compat("pr review --body-file")
-
-    selected_modes = [approve, comment, request_changes]
-    if sum(1 for selected in selected_modes if selected) != 1:
-        raise click.ClickException("Specify exactly one of --approve, --comment, or --request-changes.")
-    if (comment or request_changes) and not body:
-        raise click.ClickException("Body is required when using --comment or --request-changes.")
-
-    adapter = PullRequestAdapter(service)
-    result = adapter.review_pr(
-        owner,
-        repo,
-        number,
-        approve=approve,
-        body=body,
-        comment=comment,
-        request_changes=request_changes,
-        force=force,
-    )
-    if result.degraded:
-        safe_echo(f"Posted pull request comment {result.item['id']}")
-        raise click.ClickException(result.message or "degraded review operation")
-    if comment:
-        safe_echo(f"Posted pull request comment {result.item['id']}")
-        return
-    safe_echo(f"Reviewed pull request #{number}")
-
-
-@pr_group.command("reopen")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
-@click.argument("identifier", required=False)
-@click.pass_context
-def pr_reopen(ctx: click.Context, repo_name: str | None, identifier: str | None) -> None:
-    app = ctx.obj["app"]
-    owner, repo = resolve_repo(repo_name or app.repo)
-    service = PullRequestService(app.client())
-    resolved_identifier = resolve_pr_identifier_or_current_branch(identifier)
-    owner, repo, number = resolve_pr_arg(resolved_identifier, owner, repo, service)
-    number = int(number)
-    item = service.update(owner, repo, number, state="open")
-    safe_echo(f"Reopened pull request #{safe_number(item, number)}")
-
-
-@pr_group.command("edit")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
-@click.argument("identifier", required=False)
-@click.option("-t", "--title")
-@click.option("-b", "--body")
-@click.option("-F", "--body-file")
-@click.option("-B", "--base")
-@click.option("-a", "--add-assignee")
-@click.option("-l", "--add-label")
-@click.option("-r", "--add-reviewer")
-@click.option("--remove-assignee")
-@click.option("--remove-label")
-@click.option("--remove-reviewer")
-@click.option("-m", "--milestone")
-@click.option("--remove-milestone", is_flag=True, help="Remove the milestone from the pull request.")
-@click.pass_context
-def pr_edit(
-    ctx: click.Context,
-    repo_name: str | None,
-    identifier: str | None,
-    title: str | None,
-    body: str | None,
-    body_file: str | None,
-    base: str | None,
-    add_assignee: str | None,
-    add_label: str | None,
-    add_reviewer: str | None,
-    remove_assignee: str | None,
-    remove_label: str | None,
-    remove_reviewer: str | None,
-    milestone: str | None,
-    remove_milestone: bool,
-) -> None:
-    app = ctx.obj["app"]
-    owner, repo = resolve_repo(repo_name or app.repo)
-    service = PullRequestService(app.client())
-    resolved_identifier = resolve_pr_identifier_or_current_branch(identifier)
-    owner, repo, number = resolve_pr_arg(resolved_identifier, owner, repo, service)
-    number = int(number)
-    if body_file:
-        body = read_body_file(body_file)
-    if not any(
-        [
-            title is not None,
-            body is not None,
-            base is not None,
-            add_assignee is not None,
-            add_label is not None,
-            add_reviewer is not None,
-            remove_assignee is not None,
-            remove_label is not None,
-            remove_reviewer is not None,
-            milestone is not None,
-            remove_milestone,
-        ]
-    ):
-        raise click.UsageError("must specify at least one field to edit")
-    adapter = PullRequestAdapter(service)
-    item = adapter.edit_pr(
-        owner,
-        repo,
-        number,
-        title=title,
-        body=body,
-        base=base,
-        add_assignee=add_assignee,
-        add_label=add_label,
-        add_reviewer=add_reviewer,
-        remove_assignee=remove_assignee,
-        remove_label=remove_label,
-        remove_reviewer=remove_reviewer,
-        milestone=milestone,
-        remove_milestone=remove_milestone,
-    )
-    safe_echo(f"Edited pull request #{safe_number(item, number)}")
 
 
 @pr_group.command("diff")

--- a/src/gitcode_cli/services/__init__.py
+++ b/src/gitcode_cli/services/__init__.py
@@ -2,5 +2,6 @@ from __future__ import annotations
 
 from .issues import IssueService
 from .pulls import PullRequestService
+from .users import UserService
 
-__all__ = ["IssueService", "PullRequestService"]
+__all__ = ["IssueService", "PullRequestService", "UserService"]

--- a/src/gitcode_cli/services/issues.py
+++ b/src/gitcode_cli/services/issues.py
@@ -28,3 +28,9 @@ class IssueService:
 
     def comment(self, owner: str, repo: str, number: str, body: str) -> Any | None:
         return self.client.post(f"/repos/{owner}/{repo}/issues/{number}/comments", json={"body": body})
+
+    def update_comment(self, owner: str, repo: str, comment_id: int | str, body: str) -> Any | None:
+        return self.client.patch(f"/repos/{owner}/{repo}/issues/comments/{comment_id}", json={"body": body})
+
+    def delete_comment(self, owner: str, repo: str, comment_id: int | str) -> Any | None:
+        return self.client.delete(f"/repos/{owner}/{repo}/issues/comments/{comment_id}")

--- a/src/gitcode_cli/services/users.py
+++ b/src/gitcode_cli/services/users.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..client import GitCodeClient
+
+
+class UserService:
+    def __init__(self, client: GitCodeClient):
+        self.client = client
+
+    def current(self) -> Any | None:
+        return self.client.get("/user")

--- a/tests/contracts/test_gitcode_api_contracts.py
+++ b/tests/contracts/test_gitcode_api_contracts.py
@@ -124,6 +124,29 @@ class TestIssueServiceContracts:
         request_fields = {field["name"] for field in contract["requestBodyFields"]}
         assert "body" in request_fields
 
+    def test_update_comment_matches_issue_comment_update_contract(
+        self, issue_service: tuple[IssueService, MagicMock]
+    ) -> None:
+        service, client = issue_service
+
+        service.update_comment("owner", "repo", "7", "Updated body")
+
+        client.patch.assert_called_once_with(
+            "/repos/owner/repo/issues/comments/7",
+            json={"body": "Updated body"},
+        )
+
+    def test_delete_comment_matches_issue_comment_delete_contract(
+        self, issue_service: tuple[IssueService, MagicMock]
+    ) -> None:
+        service, client = issue_service
+
+        service.delete_comment("owner", "repo", "7")
+
+        client.delete.assert_called_once_with(
+            "/repos/owner/repo/issues/comments/7",
+        )
+
 
 class TestPullRequestServiceContracts:
     def test_list_matches_pr_list_contract(self, pull_service: tuple[PullRequestService, MagicMock]) -> None:

--- a/tests/unit/adapters/test_issue_adapter.py
+++ b/tests/unit/adapters/test_issue_adapter.py
@@ -13,8 +13,13 @@ def service():
 
 
 @pytest.fixture
-def adapter(service):
-    return IssueAdapter(service)
+def user_service():
+    return MagicMock()
+
+
+@pytest.fixture
+def adapter(service, user_service):
+    return IssueAdapter(service, user_service)
 
 
 class TestIssueAdapter:
@@ -67,6 +72,74 @@ class TestIssueAdapter:
             labels="bug,docs",
             milestone="v1",
         )
+
+    def test_manage_comment_history_edits_last_owned_comment(self, adapter, service, user_service):
+        user_service.current.return_value = {"login": "alice"}
+        service.list_comments.return_value = [
+            {"id": 1, "user": {"login": "bob"}},
+            {"id": 2, "user": {"login": "alice"}},
+        ]
+        service.update_comment.return_value = {"id": 2, "body": "updated"}
+
+        result = adapter.manage_comment_history(
+            "owner",
+            "repo",
+            "42",
+            body="updated",
+            delete_last=False,
+            create_if_none=False,
+        )
+
+        service.update_comment.assert_called_once_with("owner", "repo", 2, "updated")
+        assert result.message == "edited"
+
+    def test_manage_comment_history_creates_when_none_and_allowed(self, adapter, service, user_service):
+        user_service.current.return_value = {"login": "alice"}
+        service.list_comments.return_value = [{"id": 1, "user": {"login": "bob"}}]
+        service.comment.return_value = {"id": 3, "html_url": "https://example.com/comments/3"}
+
+        result = adapter.manage_comment_history(
+            "owner",
+            "repo",
+            "42",
+            body="new comment",
+            delete_last=False,
+            create_if_none=True,
+        )
+
+        service.comment.assert_called_once_with("owner", "repo", "42", "new comment")
+        assert result.message == "created"
+
+    def test_manage_comment_history_deletes_last_owned_comment(self, adapter, service, user_service):
+        user_service.current.return_value = {"login": "alice"}
+        service.list_comments.return_value = [{"id": 2, "author": {"login": "alice"}}]
+
+        result = adapter.manage_comment_history(
+            "owner",
+            "repo",
+            "42",
+            body=None,
+            delete_last=True,
+            create_if_none=False,
+        )
+
+        service.delete_comment.assert_called_once_with("owner", "repo", 2)
+        assert result.message == "deleted"
+
+    def test_manage_comment_history_refuses_when_current_user_cannot_be_verified(self, service):
+        adapter = IssueAdapter(service, None)
+
+        with pytest.raises(Exception) as exc:
+            adapter.manage_comment_history(
+                "owner",
+                "repo",
+                "42",
+                body="updated",
+                delete_last=False,
+                create_if_none=False,
+            )
+
+        assert "refusing to edit or delete comments safely" in str(exc.value)
 
     def test_edit_issue_merges_existing_labels(self, adapter, service):
         service.get.return_value = {"labels": [{"name": "existing"}, {"name": "bug"}]}

--- a/tests/unit/adapters/test_pulls_adapter.py
+++ b/tests/unit/adapters/test_pulls_adapter.py
@@ -78,6 +78,29 @@ class TestPullRequestAdapter:
             "milestone": "v1",
         }
 
+    def test_merge_pr_maps_supported_gh_flags_to_gitcode_payload(self, adapter, service):
+        service.merge.return_value = {"message": "Merged"}
+
+        adapter.merge_pr(
+            "owner",
+            "repo",
+            42,
+            merge_method="squash",
+            body="Merge body",
+            subject="Merge subject",
+            admin=True,
+        )
+
+        service.merge.assert_called_once_with(
+            "owner",
+            "repo",
+            42,
+            merge_method="squash",
+            description="Merge body",
+            title="Merge subject",
+            force_merge=True,
+        )
+
     def test_review_pr_approve_calls_review_api(self, adapter, service):
         service.review.return_value = {"state": "APPROVED"}
 

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -424,6 +424,15 @@ class TestIssueComment:
         assert "Editor was closed without saving a comment." in result.output
         mock_client.post.assert_not_called()
 
+    def test_edit_last_editor_cancel_returns_error(self, runner, mock_client, mock_repo, monkeypatch):
+        monkeypatch.setattr("gitcode_cli.commands.issue.get_body_from_options", lambda **kwargs: None)
+        result = runner.invoke(main, ["issue", "comment", "42", "--edit-last", "-e"])
+        assert result.exit_code != 0
+        assert "Editor was closed without saving a comment." in result.output
+        mock_client.get.assert_not_called()
+        mock_client.patch.assert_not_called()
+        mock_client.post.assert_not_called()
+
     def test_web_opens_issue_page_without_posting(self, runner, mock_client, mock_repo):
         with patch("gitcode_cli.commands.issue.open_in_browser") as mock_browser:
             result = runner.invoke(main, ["issue", "comment", "42", "--web"])

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -227,9 +227,9 @@ class TestIssueView:
         mock_client.get.side_effect = APIError("Issue not found", 404)
         result = runner.invoke(main, ["issue", "view", "42"])
         assert result.exit_code != 0
-        assert "error: Issue not found" in result.output
-        assert "Traceback" not in result.output
 
+
+class TestIssueCreate:
     def test_default(self, runner, mock_client, mock_repo):
         result = runner.invoke(main, ["issue", "create", "-t", "Test Title", "-b", "Body"])
         assert result.exit_code == 0
@@ -303,13 +303,29 @@ class TestIssueView:
         assert json_data["labels"] == "bug"
         assert json_data["milestone"] == "v1.0"
 
-    def test_editor_fails_before_prompting_for_title(self, runner, mock_client, mock_repo):
-        result = runner.invoke(main, ["issue", "create", "--editor"], input="Should not be consumed\n")
-        assert result.exit_code != 0
-        assert (
-            "gh-compatible command/flag 'issue create --editor' is recognized but not implemented yet." in result.output
+    def test_editor_uses_prompted_title_before_body_editing(self, runner, mock_client, mock_repo, monkeypatch):
+        monkeypatch.setattr(
+            "gitcode_cli.commands.issue.get_body_from_options", lambda **kwargs: "issue body from editor"
         )
-        assert "Title" not in result.output
+        result = runner.invoke(main, ["issue", "create", "--editor"], input="Prompted Title\n")
+        assert result.exit_code == 0
+        assert "Title" in result.output
+        assert mock_client.post.call_args[1]["json"]["title"] == "Prompted Title"
+        assert mock_client.post.call_args[1]["json"]["body"] == "issue body from editor"
+
+    def test_editor_uses_body_helper_and_posts_saved_content(self, runner, mock_client, mock_repo, monkeypatch):
+        monkeypatch.setattr(
+            "gitcode_cli.commands.issue.get_body_from_options", lambda **kwargs: "issue body from editor"
+        )
+        result = runner.invoke(main, ["issue", "create", "--editor", "-t", "Title"])
+        assert result.exit_code == 0
+        assert mock_client.post.call_args[1]["json"]["body"] == "issue body from editor"
+
+    def test_editor_closed_without_saving_returns_error(self, runner, mock_client, mock_repo, monkeypatch):
+        monkeypatch.setattr("gitcode_cli.commands.issue.get_body_from_options", lambda **kwargs: None)
+        result = runner.invoke(main, ["issue", "create", "--editor", "-t", "Title"])
+        assert result.exit_code != 0
+        assert "Editor was closed without saving an issue body." in result.output
         mock_client.post.assert_not_called()
 
 
@@ -334,12 +350,11 @@ class TestIssueClose:
         assert result.exit_code == 0
         assert "Closed issue #42" in result.output
 
-    def test_close_without_number_or_iid_in_response(self, runner, mock_client, mock_repo):
-        mock_client.get.return_value = {"number": "42", "state": "open"}
-        mock_client.patch.return_value = {"state": "closed"}
-        result = runner.invoke(main, ["issue", "close", "42"])
-        assert result.exit_code == 0
-        assert "Closed issue #42" in result.output
+    def test_close_rejects_non_numeric_identifier(self, runner, mock_client, mock_repo):
+        result = runner.invoke(main, ["issue", "close", "not-a-number"])
+        assert result.exit_code != 0
+        assert "Issue identifier must be a number or a valid issue URL." in result.output
+        mock_client.patch.assert_not_called()
 
 
 class TestIssueCloseIdempotency:
@@ -416,9 +431,62 @@ class TestIssueComment:
         mock_client.post.assert_not_called()
         mock_browser.assert_called_once_with("https://gitcode.com/owner/repo/issues/42")
 
-    def test_url(self, runner, mock_client):
-        result = runner.invoke(main, ["issue", "comment", "https://gitcode.com/owner/repo/issues/42", "-b", "hi"])
+    def test_comment_rejects_non_numeric_identifier(self, runner, mock_client, mock_repo):
+        result = runner.invoke(main, ["issue", "comment", "not-a-number", "-b", "hi"])
+        assert result.exit_code != 0
+        assert "Issue identifier must be a number or a valid issue URL." in result.output
+        mock_client.post.assert_not_called()
+
+    def test_edit_last_updates_last_owned_comment(self, runner, mock_client, mock_repo):
+        mock_client.get.side_effect = [
+            {"login": "alice"},
+            [{"id": 11, "user": {"login": "alice"}, "body": "old"}],
+        ]
+        result = runner.invoke(main, ["issue", "comment", "42", "--edit-last", "-b", "new body"])
         assert result.exit_code == 0
+        assert mock_client.patch.call_args.kwargs["json"]["body"] == "new body"
+        assert "/issues/comments/11" in mock_client.patch.call_args.args[0]
+
+    def test_edit_last_create_if_none_creates_comment(self, runner, mock_client, mock_repo):
+        mock_client.get.side_effect = [
+            {"login": "alice"},
+            [{"id": 11, "user": {"login": "bob"}, "body": "other"}],
+        ]
+        mock_client.post.return_value = {"id": 22, "html_url": "https://example.com/comments/22"}
+        result = runner.invoke(main, ["issue", "comment", "42", "--edit-last", "--create-if-none", "-b", "new body"])
+        assert result.exit_code == 0
+        assert mock_client.post.call_args.kwargs["json"]["body"] == "new body"
+
+    def test_delete_last_requires_confirmation_by_default(self, runner, mock_client, mock_repo):
+        result = runner.invoke(main, ["issue", "comment", "42", "--delete-last"], input="n\n")
+        assert result.exit_code != 0
+        assert "Aborted." in result.output
+        mock_client.delete.assert_not_called()
+
+    def test_delete_last_yes_skips_confirmation(self, runner, mock_client, mock_repo):
+        mock_client.get.side_effect = [
+            {"login": "alice"},
+            [{"id": 11, "author": {"login": "alice"}, "body": "old"}],
+        ]
+        result = runner.invoke(main, ["issue", "comment", "42", "--delete-last", "--yes"])
+        assert result.exit_code == 0
+        mock_client.delete.assert_called_once()
+
+    def test_create_if_none_requires_edit_last(self, runner, mock_client, mock_repo):
+        result = runner.invoke(main, ["issue", "comment", "42", "--create-if-none", "-b", "new body"])
+        assert result.exit_code != 0
+        assert "only be used together with --edit-last" in result.output
+
+    def test_yes_requires_delete_last(self, runner, mock_client, mock_repo):
+        result = runner.invoke(main, ["issue", "comment", "42", "--yes", "-b", "new body"])
+        assert result.exit_code != 0
+        assert "can only be used together with --delete-last" in result.output
+
+    def test_history_management_refuses_when_current_user_is_unverifiable(self, runner, mock_client, mock_repo):
+        mock_client.get.side_effect = [{}, []]
+        result = runner.invoke(main, ["issue", "comment", "42", "--edit-last", "-b", "new body"])
+        assert result.exit_code != 0
+        assert "refusing to edit or delete comments safely" in result.output
 
 
 class TestIssueReopen:
@@ -434,12 +502,11 @@ class TestIssueReopen:
         result = runner.invoke(main, ["issue", "reopen", "https://gitcode.com/owner/repo/issues/42"])
         assert result.exit_code == 0
 
-    def test_reopen_without_number_in_response(self, runner, mock_client, mock_repo):
-        mock_client.get.return_value = {"number": "42", "state": "closed"}
-        mock_client.patch.return_value = {"iid": "42", "state": "open"}
-        result = runner.invoke(main, ["issue", "reopen", "42"])
-        assert result.exit_code == 0
-        assert "Reopened issue #42" in result.output
+    def test_reopen_rejects_non_numeric_identifier(self, runner, mock_client, mock_repo):
+        result = runner.invoke(main, ["issue", "reopen", "not-a-number"])
+        assert result.exit_code != 0
+        assert "Issue identifier must be a number or a valid issue URL." in result.output
+        mock_client.patch.assert_not_called()
 
 
 class TestIssueReopenIdempotency:

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -463,8 +463,38 @@ class TestPrMerge:
         assert "this patch has already been applied" in result.output
         assert "Traceback" not in result.output
 
+    def test_pr_merge_body_subject_and_admin_map_to_merge_payload(self, runner, mock_client, mock_repo):
+        result = runner.invoke(
+            main,
+            ["pr", "merge", "42", "--body", "Merge body", "--subject", "Merge subject", "--admin"],
+        )
+        assert result.exit_code == 0
+        assert mock_client.put.call_args.kwargs["json"] == {
+            "merge_method": "merge",
+            "description": "Merge body",
+            "title": "Merge subject",
+            "force_merge": True,
+        }
 
-class TestPrComment:
+    def test_pr_merge_body_file_maps_to_description(self, runner, mock_client, mock_repo, tmp_path):
+        body_file = tmp_path / "merge-body.txt"
+        body_file.write_text("file merge body")
+        result = runner.invoke(main, ["pr", "merge", "42", "-F", str(body_file)])
+        assert result.exit_code == 0
+        assert mock_client.put.call_args.kwargs["json"]["description"] == "file merge body"
+
+    def test_pr_merge_author_email_remains_unsupported(self, runner, mock_client, mock_repo):
+        result = runner.invoke(main, ["pr", "merge", "42", "--author-email", "a@example.com"])
+        assert result.exit_code != 0
+        assert "does not support --author-email" in result.output
+        mock_client.put.assert_not_called()
+
+    def test_pr_merge_auto_remains_unsupported(self, runner, mock_client, mock_repo):
+        result = runner.invoke(main, ["pr", "merge", "42", "--auto"])
+        assert result.exit_code != 0
+        assert "does not support --auto" in result.output
+        mock_client.put.assert_not_called()
+
     def test_pr_comment(self, runner, mock_client, mock_repo):
         mock_client.post.return_value = {"id": 123}
         result = runner.invoke(main, ["pr", "comment", "42", "--body", "hi"])
@@ -548,6 +578,24 @@ class TestPrReview:
         result = runner.invoke(main, ["pr", "review", "42", "--request-changes", "--body", "Please address feedback"])
         assert result.exit_code != 0
         assert "Posted pull request comment 456" in result.output
+
+    def test_pr_review_comment_supports_body_file(self, runner, mock_client, mock_repo, tmp_path):
+        body_file = tmp_path / "review.txt"
+        body_file.write_text("Needs more tests from file")
+        mock_client.post.return_value = {"id": 123}
+        result = runner.invoke(main, ["pr", "review", "42", "--comment", "-F", str(body_file)])
+        assert result.exit_code == 0
+        comment_calls = [c for c in mock_client.post.call_args_list if "comments" in c.args[0]]
+        assert comment_calls[0].kwargs["json"]["body"] == "Needs more tests from file"
+
+    def test_pr_review_request_changes_supports_body_file(self, runner, mock_client, mock_repo, tmp_path):
+        body_file = tmp_path / "review.txt"
+        body_file.write_text("Please address feedback from file")
+        mock_client.post.return_value = {"id": 456}
+        result = runner.invoke(main, ["pr", "review", "42", "--request-changes", "-F", str(body_file)])
+        assert result.exit_code != 0
+        comment_calls = [c for c in mock_client.post.call_args_list if "comments" in c.args[0]]
+        assert comment_calls[0].kwargs["json"]["body"] == "Please address feedback from file"
 
 
 class TestPrReopen:


### PR DESCRIPTION
## Description

Implement the subset of pending gh-compatible flows that already map cleanly to GitCode APIs or local CLI behavior.

This PR:
- enables `pr merge --body/--body-file/--subject/--admin` while keeping unsupported merge flags blocked
- enables `pr review --body-file` without changing the existing degraded `--request-changes` behavior
- enables `issue create --editor`
- adds conservative `issue comment` history-management support for `--edit-last`, `--delete-last`, `--create-if-none`, and `--yes`
- adds service/adapter/command tests and contract coverage for the new paths

## Related Issue

Partially addresses #68

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [ ] Lint passes (`python -m ruff check src/ tests/`)
- [ ] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

Additional verification run for this change set:
- `PYTHONPATH=/Users/test1/liuyekang/dev/cli/gitcode-cli/.worktrees/feat-gh-compat-pending-repair/src conda run -n gitcode-cli python -m pytest --no-cov -q tests/unit/adapters/test_pulls_adapter.py tests/unit/adapters/test_issue_adapter.py tests/unit/commands/test_pr.py tests/unit/commands/test_issue.py tests/contracts/test_gitcode_api_contracts.py`

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [ ] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide