### PR TITLE
fix: avoid crash after issue comment edit

### DIFF
--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -80,7 +80,7 @@ def _handle_issue_comment_history(
     if result.message == "created":
         safe_echo(result.item.get("html_url") or f"Commented on issue #{number}")
         return
-    safe_echo(result.item.get("html_url") or f"Edited last comment on issue #{number}")
+    safe_echo((result.item or {}).get("html_url") or f"Edited last comment on issue #{number}")
 
 
 @click.group("issue")

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -456,6 +456,16 @@ class TestIssueComment:
         assert mock_client.patch.call_args.kwargs["json"]["body"] == "new body"
         assert "/issues/comments/11" in mock_client.patch.call_args.args[0]
 
+    def test_edit_last_succeeds_when_update_returns_none(self, runner, mock_client, mock_repo):
+        mock_client.get.side_effect = [
+            {"login": "alice"},
+            [{"id": 11, "user": {"login": "alice"}, "body": "old"}],
+        ]
+        mock_client.patch.return_value = None
+        result = runner.invoke(main, ["issue", "comment", "42", "--edit-last", "-b", "new body"])
+        assert result.exit_code == 0
+        assert "Edited last comment on issue #42" in result.output
+
     def test_edit_last_create_if_none_creates_comment(self, runner, mock_client, mock_repo):
         mock_client.get.side_effect = [
             {"login": "alice"},


### PR DESCRIPTION
## Description

- guard the `--edit-last` success path when the comment update API returns no payload
- fall back to a plain success message instead of raising `AttributeError`
- add a regression test for the empty-payload edit case

## Related Issue

Fixes #74

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

Validation run:
- `conda run -n gitcode-cli pytest -o addopts='' tests/unit/commands/test_issue.py -k edit_last`
- `conda run -n gitcode-cli pytest -o addopts='' tests/unit/adapters/test_issue_adapter.py`
- `conda run -n gitcode-cli python -m ruff check src tests`
- `conda run -n gitcode-cli python -m ruff format --check src tests`
- `conda run -n gitcode-cli python -m basedpyright src`
- `pytest` pre-commit hook passed during commit

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [ ] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide