### PR TITLE
feat: align help output with gh sections

### DIFF
--- a/src/gitcode_cli/cli.py
+++ b/src/gitcode_cli/cli.py
@@ -14,6 +14,7 @@ from .commands.pr import pr_group
 from .config import get_token
 from .context import AppContext
 from .errors import GCError
+from .helptext import GCSectionGroup, set_gc_help
 from .utils import safe_echo
 
 
@@ -33,7 +34,7 @@ def _get_version() -> str:
         return __version__
 
 
-class _GCMainGroup(click.Group):
+class _GCMainGroup(GCSectionGroup):
     def invoke(self, ctx: click.Context):
         try:
             return super().invoke(ctx)
@@ -42,9 +43,13 @@ class _GCMainGroup(click.Group):
             ctx.exit(1)
 
 
-@click.group(cls=_GCMainGroup, context_settings={"help_option_names": ["-h", "--help"]})
+@click.group(
+    cls=_GCMainGroup,
+    context_settings={"help_option_names": ["-h", "--help"]},
+    help="Work seamlessly with GitCode from the command line.",
+)
 @click.version_option(version=_get_version(), prog_name="gitcode")
-@click.option("--repo", "repo_name", "-R", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("--repo", "repo_name", "-R", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.option("--token", hidden=True, help="Override authentication token.")
 @click.pass_context
 def main(ctx: click.Context, repo_name: str | None, token: str | None) -> None:
@@ -57,12 +62,35 @@ def main(ctx: click.Context, repo_name: str | None, token: str | None) -> None:
     ctx.obj["app"] = AppContext(token=resolved_token or "", repo=repo_name)
 
 
-@main.command("version")
+set_gc_help(
+    main,
+    gc_usage="gc <command> <subcommand> [flags]",
+    gc_command_sections=[
+        ("CORE COMMANDS", ["auth", "issue", "pr"]),
+        ("ADDITIONAL COMMANDS", ["completion", "version"]),
+    ],
+    gc_examples=[
+        "gc issue create",
+        "gc pr list -R owner/repo",
+        "gc auth login",
+    ],
+    gc_learn_more=[
+        "Use `gc <command> <subcommand> --help` for more information about a command.",
+    ],
+)
+
+
+auth_group.short_help = "Authenticate gc with GitCode"
+issue_group.short_help = "Manage issues"
+pr_group.short_help = "Manage pull requests"
+
+
+@main.command("version", short_help="Show gc version", help="Show gc version.")
 def version_command() -> None:
     safe_echo(f"gitcode version {_get_version()}")
 
 
-@main.command("completion")
+@main.command("completion", short_help="Generate shell completion scripts", help="Generate shell completion scripts.")
 @click.argument("shell", type=click.Choice(["bash", "zsh", "fish"]))
 def completion_command(shell: str) -> None:
     comp_class = get_completion_class(shell)

--- a/src/gitcode_cli/commands/auth.py
+++ b/src/gitcode_cli/commands/auth.py
@@ -3,15 +3,16 @@ from __future__ import annotations
 import click
 
 from ..config import get_token, load_config, save_config
+from ..helptext import GCSectionGroup
 from ..utils import safe_echo
 
 
-@click.group("auth")
+@click.group("auth", cls=GCSectionGroup, help="Authenticate gc with GitCode.")
 def auth_group() -> None:
     pass
 
 
-@auth_group.command("login")
+@auth_group.command("login", short_help="Authenticate with a GitCode token", help="Authenticate with a GitCode token.")
 @click.option("--with-token", is_flag=True, help="Read token from stdin.")
 def auth_login(with_token: bool) -> None:
     if with_token:
@@ -24,7 +25,7 @@ def auth_login(with_token: bool) -> None:
     safe_echo("Authentication saved.")
 
 
-@auth_group.command("logout")
+@auth_group.command("logout", short_help="Remove saved authentication", help="Remove saved authentication.")
 def auth_logout() -> None:
     config = load_config()
     if "token" not in config:
@@ -34,7 +35,7 @@ def auth_logout() -> None:
     safe_echo("Logged out.")
 
 
-@auth_group.command("status")
+@auth_group.command("status", short_help="Show authentication status", help="Show authentication status.")
 def auth_status() -> None:
     try:
         token = get_token()
@@ -45,7 +46,7 @@ def auth_status() -> None:
     safe_echo(f"Logged in to GitCode (token: {masked})")
 
 
-@auth_group.command("token")
+@auth_group.command("token", short_help="Print the active token", help="Print the active token.")
 def auth_token() -> None:
     try:
         token = get_token()

--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -6,6 +6,7 @@ from ..adapters import IssueAdapter
 from ..adapters.capabilities import capability_message
 from ..cli_compat import get_body_from_options
 from ..formatters import format_issue_detail, format_issue_list, output_result
+from ..helptext import GCSectionGroup, set_gc_help
 from ..repo import resolve_repo
 from ..services import IssueService, UserService
 from ..utils import (
@@ -83,13 +84,13 @@ def _handle_issue_comment_history(
     safe_echo((result.item or {}).get("html_url") or f"Edited last comment on issue #{number}")
 
 
-@click.group("issue")
+@click.group("issue", cls=GCSectionGroup, help="Work with GitCode issues.")
 def issue_group() -> None:
     pass
 
 
 @issue_group.command("list")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.option("-s", "--state")
 @click.option("-l", "--label", "labels", multiple=True)
 @click.option("-A", "--author")
@@ -154,7 +155,7 @@ def issue_list(
 
 
 @issue_group.command("view")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier")
 @click.option("-w", "--web", is_flag=True, help="Open the issue in the web browser.")
 @click.option("-c", "--comments", is_flag=True, help="View issue comments.")
@@ -216,7 +217,7 @@ def issue_view(
 
 
 @issue_group.command("create")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.option("-t", "--title")
 @click.option("-b", "--body")
 @click.option("-a", "--assignee")
@@ -276,7 +277,7 @@ def issue_create(
 
 
 @issue_group.command("close")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier")
 @click.option("-c", "--comment", help="Leave a closing comment.")
 @click.option("--duplicate-of")
@@ -313,7 +314,7 @@ def issue_close(
 
 
 @issue_group.command("comment")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier")
 @click.option("-b", "--body")
 @click.option("-F", "--body-file")
@@ -377,7 +378,7 @@ def issue_comment(
 
 
 @issue_group.command("reopen")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier")
 @click.pass_context
 def issue_reopen(ctx: click.Context, repo_name: str | None, identifier: str) -> None:
@@ -399,7 +400,7 @@ def issue_reopen(ctx: click.Context, repo_name: str | None, identifier: str) -> 
 
 
 @issue_group.command("edit")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier")
 @click.option("-t", "--title")
 @click.option("-b", "--body")
@@ -458,7 +459,7 @@ def issue_edit(
 
 
 @issue_group.command("delete")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier")
 @click.pass_context
 def issue_delete(ctx: click.Context, repo_name: str | None, identifier: str) -> None:
@@ -476,7 +477,7 @@ def issue_delete(ctx: click.Context, repo_name: str | None, identifier: str) -> 
 
 
 @issue_group.command("status")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.pass_context
 def issue_status(ctx: click.Context, repo_name: str | None) -> None:
     app = ctx.obj["app"]
@@ -491,7 +492,7 @@ def issue_status(ctx: click.Context, repo_name: str | None) -> None:
 
 
 @issue_group.command("develop")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier")
 @click.option("-b", "--base", help="Base branch for the develop branch.")
 @click.option("-n", "--name", help="Name for the local branch.")
@@ -523,3 +524,70 @@ def issue_develop(
 
 issue_group.add_command(issue_list, name="ls")
 issue_group.add_command(issue_create, name="new")
+
+set_gc_help(
+    issue_group,
+    gc_usage="gc issue <command> [flags]",
+    gc_command_sections=[
+        ("GENERAL COMMANDS", ["create", "list", "status"]),
+        ("TARGETED COMMANDS", ["close", "comment", "delete", "develop", "edit", "reopen", "view"]),
+    ],
+    gc_examples=[
+        "gc issue list",
+        "gc issue create --label bug",
+        "gc issue view 123 --web",
+    ],
+    gc_arguments_help=[
+        "An issue can be supplied as argument in any of the following formats:",
+        '- by number, e.g. "123"; or',
+        '- by URL, e.g. "https://gitcode.com/OWNER/REPO/issues/123".',
+    ],
+)
+
+set_gc_help(
+    issue_list,
+    gc_usage="gc issue list [flags]",
+    gc_aliases=["ls"],
+    gc_json_fields=[
+        "author",
+        "assignees",
+        "body",
+        "comments",
+        "createdAt",
+        "labels",
+        "milestone",
+        "number",
+        "state",
+        "title",
+        "updatedAt",
+        "url",
+    ],
+    gc_examples=[
+        'gc issue list --label "bug" --label "help wanted"',
+        "gc issue list --author monalisa",
+        "gc issue list --assignee @me",
+        'gc issue list --milestone "The big 1.0"',
+        'gc issue list --search "error no:assignee sort:created-asc"',
+        "gc issue list --state all",
+    ],
+)
+
+issue_view.short_help = "View an issue"
+issue_view.help = "View an issue."
+issue_create.short_help = "Create a new issue"
+issue_create.help = "Create a new issue."
+set_gc_help(issue_create, gc_aliases=["new"])
+issue_close.short_help = "Close issue"
+issue_close.help = "Close issue."
+issue_comment.short_help = "Add a comment to an issue"
+issue_comment.help = "Add a comment to an issue."
+issue_reopen.short_help = "Reopen issue"
+issue_reopen.help = "Reopen issue."
+issue_edit.short_help = "Edit issues"
+issue_edit.help = "Edit issues."
+issue_delete.short_help = "Delete issue"
+issue_delete.help = "Delete issue."
+issue_status.short_help = "Show status of relevant issues"
+issue_status.help = "Show status of relevant issues."
+issue_develop.short_help = "Manage linked branches for an issue"
+issue_develop.help = "Manage linked branches for an issue."

--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -544,6 +544,8 @@ set_gc_help(
     ],
 )
 
+issue_list.short_help = "List issues in a repository"
+issue_list.help = "List issues in a repository. By default, this only lists open issues."
 set_gc_help(
     issue_list,
     gc_usage="gc issue list [flags]",

--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -13,6 +13,7 @@ from ..cli_compat import (
     resolve_pr_identifier_or_current_branch,
 )
 from ..formatters import format_pr_detail, format_pr_list, output_result
+from ..helptext import GCSectionGroup, set_gc_help
 from ..repo import resolve_repo
 from ..services import PullRequestService
 from ..utils import (
@@ -30,13 +31,13 @@ def _pending_gh_compat(name: str) -> None:
     raise click.ClickException(f"gh-compatible command/flag '{name}' is recognized but not implemented yet.")
 
 
-@click.group("pr")
+@click.group("pr", cls=GCSectionGroup, help="Work with GitCode pull requests.")
 def pr_group() -> None:
     pass
 
 
 @pr_group.command("merge")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier", required=False)
 @click.option("-m", "--merge", is_flag=True, help="Merge the pull request.")
 @click.option("-s", "--squash", is_flag=True, help="Squash the pull request.")
@@ -96,7 +97,7 @@ def pr_merge(
 
 
 @pr_group.command("comment")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier", required=False)
 @click.option("-b", "--body")
 @click.option("-F", "--body-file")
@@ -133,7 +134,7 @@ def pr_comment(
 
 
 @pr_group.command("review")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier", required=False)
 @click.option("-a", "--approve", is_flag=True, help="Approve the pull request. GitCode maps this to its review API.")
 @click.option("-b", "--body")
@@ -187,7 +188,7 @@ def pr_review(
 
 
 @pr_group.command("reopen")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier", required=False)
 @click.pass_context
 def pr_reopen(ctx: click.Context, repo_name: str | None, identifier: str | None) -> None:
@@ -202,7 +203,7 @@ def pr_reopen(ctx: click.Context, repo_name: str | None, identifier: str | None)
 
 
 @pr_group.command("edit")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier", required=False)
 @click.option("-t", "--title")
 @click.option("-b", "--body")
@@ -279,7 +280,7 @@ def pr_edit(
 
 
 @pr_group.command("list")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.option("-s", "--state")
 @click.option("-A", "--author")
 @click.option("-B", "--base")
@@ -347,7 +348,7 @@ def pr_list(
 
 
 @pr_group.command("view")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier", required=False)
 @click.option("-w", "--web", is_flag=True, help="Open the pull request in the web browser.")
 @click.option("-c", "--comments", is_flag=True, help="View pull request comments.")
@@ -405,7 +406,7 @@ def pr_view(
 
 
 @pr_group.command("create")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.option("-t", "--title")
 @click.option("-b", "--body")
 @click.option("-F", "--body-file")
@@ -512,7 +513,7 @@ def pr_create(
 
 
 @pr_group.command("close")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier", required=False)
 @click.option("-c", "--comment")
 @click.option("-d", "--delete-branch", is_flag=True, help="Delete the remote branch after closing.")
@@ -544,7 +545,7 @@ def pr_close(
 
 
 @pr_group.command("diff")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier", required=False)
 @click.pass_context
 def pr_diff(ctx: click.Context, repo_name: str | None, identifier: str | None) -> None:
@@ -558,7 +559,7 @@ def pr_diff(ctx: click.Context, repo_name: str | None, identifier: str | None) -
 
 
 @pr_group.command("checkout")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier", required=False)
 @click.option("-b", "--branch", help="Local branch name to checkout into.")
 @click.pass_context
@@ -579,7 +580,6 @@ def pr_checkout(ctx: click.Context, repo_name: str | None, identifier: str | Non
     except subprocess.CalledProcessError as exc:
         raise click.ClickException(f"Git fetch failed: {exc}") from exc
 
-    # Check if a local branch with this name already exists
     existing = subprocess.run(
         ["git", "rev-parse", "--verify", f"refs/heads/{local_branch}"],
         capture_output=True,
@@ -587,7 +587,6 @@ def pr_checkout(ctx: click.Context, repo_name: str | None, identifier: str | Non
         check=False,
     )
     if existing.returncode == 0:
-        # Branch exists — check if it tracks the expected remote ref
         tracking = subprocess.run(
             ["git", "for-each-ref", "--format=%(upstream:short)", f"refs/heads/{local_branch}"],
             capture_output=True,
@@ -614,7 +613,7 @@ def pr_checkout(ctx: click.Context, repo_name: str | None, identifier: str | Non
 
 
 @pr_group.command("ready")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier", required=False)
 @click.option("--undo", is_flag=True, help="Convert a pull request to draft.")
 @click.pass_context
@@ -632,7 +631,7 @@ def pr_ready(ctx: click.Context, repo_name: str | None, identifier: str | None, 
 
 
 @pr_group.command("status")
-@click.option("-R", "--repo", "repo_name", help="Repository in OWNER/REPO format (default: gitcode.com).")
+@click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.pass_context
 def pr_status(ctx: click.Context, repo_name: str | None) -> None:
     app = ctx.obj["app"]
@@ -650,3 +649,77 @@ def pr_status(ctx: click.Context, repo_name: str | None) -> None:
 
 pr_group.add_command(pr_list, name="ls")
 pr_group.add_command(pr_create, name="new")
+
+set_gc_help(
+    pr_group,
+    gc_usage="gc pr <command> [flags]",
+    gc_command_sections=[
+        ("GENERAL COMMANDS", ["create", "list", "status"]),
+        (
+            "TARGETED COMMANDS",
+            ["checkout", "close", "comment", "diff", "edit", "merge", "ready", "reopen", "review", "view"],
+        ),
+    ],
+    gc_examples=[
+        "gc pr list",
+        "gc pr create --fill",
+        "gc pr view 123 --web",
+    ],
+    gc_arguments_help=[
+        "A pull request can be supplied as argument by number or by URL.",
+        "If omitted on commands that support it, the current branch is used when possible.",
+    ],
+)
+
+pr_merge.short_help = "Merge a pull request"
+pr_merge.help = "Merge a pull request."
+pr_comment.short_help = "Add a comment to a pull request"
+pr_comment.help = "Add a comment to a pull request."
+pr_review.short_help = "Add a review to a pull request"
+pr_review.help = "Add a review to a pull request."
+pr_reopen.short_help = "Reopen pull request"
+pr_reopen.help = "Reopen pull request."
+pr_edit.short_help = "Edit pull requests"
+pr_edit.help = "Edit pull requests."
+pr_list.short_help = "List pull requests in a repository"
+pr_list.help = "List pull requests in a repository."
+set_gc_help(
+    pr_list,
+    gc_usage="gc pr list [flags]",
+    gc_aliases=["ls"],
+    gc_json_fields=[
+        "author",
+        "assignees",
+        "baseRefName",
+        "body",
+        "createdAt",
+        "headRefName",
+        "labels",
+        "number",
+        "state",
+        "title",
+        "updatedAt",
+        "url",
+    ],
+    gc_examples=[
+        'gc pr list --label "bug"',
+        "gc pr list --author monalisa",
+        'gc pr list --search "is:open review-requested:@me"',
+        "gc pr list --state all",
+    ],
+)
+pr_view.short_help = "View a pull request"
+pr_view.help = "View a pull request."
+pr_create.short_help = "Create a pull request"
+pr_create.help = "Create a pull request."
+set_gc_help(pr_create, gc_aliases=["new"])
+pr_close.short_help = "Close pull request"
+pr_close.help = "Close pull request."
+pr_diff.short_help = "View changes in a pull request"
+pr_diff.help = "View changes in a pull request."
+pr_checkout.short_help = "Check out a pull request locally"
+pr_checkout.help = "Check out a pull request locally."
+pr_ready.short_help = "Mark a pull request as ready for review"
+pr_ready.help = "Mark a pull request as ready for review."
+pr_status.short_help = "Show status of relevant pull requests"
+pr_status.help = "Show status of relevant pull requests."

--- a/src/gitcode_cli/helptext.py
+++ b/src/gitcode_cli/helptext.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import textwrap
+from typing import Any
+
+import click
+
+LEARN_MORE_LINES = [
+    "Use `gc <command> <subcommand> --help` for more information about a command.",
+]
+
+
+class GCSectionCommand(click.Command):
+    def get_help(self, ctx: click.Context) -> str:
+        return _render_help(self, ctx)
+
+
+class GCSectionGroup(click.Group):
+    command_class = GCSectionCommand
+
+    def get_help(self, ctx: click.Context) -> str:
+        return _render_help(self, ctx)
+
+
+def set_gc_help(command: click.Command, **metadata: Any) -> None:
+    for key, value in metadata.items():
+        setattr(command, key, value)
+
+
+def _render_help(command: click.Command, ctx: click.Context) -> str:
+    sections: list[str] = []
+    help_text = _clean_text(command.help)
+    if help_text:
+        sections.append(help_text)
+
+    sections.append("USAGE\n  " + _usage_line(command, ctx))
+
+    if isinstance(command, click.Group):
+        command_sections = _command_sections(command)
+        for title, section_rows in command_sections:
+            if section_rows:
+                sections.append(_definition_section(title, section_rows))
+    else:
+        aliases = getattr(command, "gc_aliases", [])
+        if aliases:
+            parent_path = _display_command_path(ctx).rsplit(" ", 1)[0]
+            sections.append("ALIASES\n" + "\n".join(f"  {parent_path} {alias}" for alias in aliases))
+
+    flag_rows = _flag_rows(command, ctx)
+    inherited_flag_rows = _inherited_flag_rows(command, ctx)
+    if flag_rows:
+        sections.append(_definition_section("FLAGS", flag_rows))
+    if inherited_flag_rows:
+        sections.append(_definition_section("INHERITED FLAGS", inherited_flag_rows))
+
+    argument_help = getattr(command, "gc_arguments_help", None)
+    if argument_help:
+        sections.append(_argument_section(argument_help))
+
+    json_fields = getattr(command, "gc_json_fields", None)
+    if json_fields:
+        sections.append(_wrapped_list_section("JSON FIELDS", json_fields))
+
+    examples = getattr(command, "gc_examples", None)
+    if examples:
+        sections.append("EXAMPLES\n" + "\n".join(f"  $ {example}" for example in examples))
+
+    learn_more = getattr(command, "gc_learn_more", LEARN_MORE_LINES)
+    if learn_more:
+        sections.append("LEARN MORE\n" + "\n".join(f"  {line}" for line in learn_more))
+
+    return "\n\n".join(section.rstrip() for section in sections if section).rstrip() + "\n"
+
+
+def _usage_line(command: click.Command, ctx: click.Context) -> str:
+    usage_suffix = getattr(command, "gc_usage", None)
+    if usage_suffix:
+        return usage_suffix
+
+    pieces = [_display_command_path(ctx)]
+    if isinstance(command, click.Group):
+        pieces.append("<command>")
+        if ctx.parent is None:
+            pieces.append("<subcommand>")
+    else:
+        for param in command.get_params(ctx):
+            if isinstance(param, click.Argument):
+                pieces.append(param.make_metavar(ctx))
+    if any(isinstance(param, click.Option) and not param.hidden for param in command.get_params(ctx)):
+        pieces.append("[flags]")
+    return " ".join(piece for piece in pieces if piece)
+
+
+def _display_command_path(ctx: click.Context) -> str:
+    parts = ctx.command_path.split()
+    if not parts:
+        return "gc"
+    parts[0] = "gc"
+    return " ".join(parts)
+
+
+def _command_sections(command: click.Group) -> list[tuple[str, list[tuple[str, str]]]]:
+    configured = getattr(command, "gc_command_sections", None)
+    if configured:
+        sections: list[tuple[str, list[tuple[str, str]]]] = []
+        for title, names in configured:
+            section_rows: list[tuple[str, str]] = []
+            for name in names:
+                subcommand = command.get_command(click.Context(command), name)
+                if subcommand is None:
+                    continue
+                section_rows.append((f"{name}:", _command_summary(subcommand)))
+            if section_rows:
+                sections.append((title, section_rows))
+        return sections
+
+    seen: set[int] = set()
+    rows: list[tuple[str, str]] = []
+    for name in command.list_commands(click.Context(command)):
+        subcommand = command.get_command(click.Context(command), name)
+        if subcommand is None or id(subcommand) in seen:
+            continue
+        seen.add(id(subcommand))
+        rows.append((f"{name}:", _command_summary(subcommand)))
+    return [("COMMANDS", rows)] if rows else []
+
+
+def _command_summary(command: click.Command) -> str:
+    return command.short_help or _first_line(command.help) or ""
+
+
+def _flag_rows(command: click.Command, ctx: click.Context) -> list[tuple[str, str]]:
+    rows: list[tuple[str, str]] = []
+    inherited_option_names = _inherited_option_names(ctx)
+    for param in command.get_params(ctx):
+        if not isinstance(param, click.Option) or param.hidden:
+            continue
+        if any(opt in inherited_option_names for opt in param.opts + param.secondary_opts):
+            continue
+        record = param.get_help_record(ctx)
+        if record is None:
+            continue
+        rows.append(record)
+    return rows
+
+
+def _inherited_flag_rows(command: click.Command, ctx: click.Context) -> list[tuple[str, str]]:
+    rows: list[tuple[str, str]] = []
+    if ctx.parent is None:
+        return rows
+    for param in ctx.parent.command.get_params(ctx.parent):
+        if not isinstance(param, click.Option) or param.hidden:
+            continue
+        if "--help" in param.opts or "-h" in param.opts:
+            continue
+        if "--version" in param.opts:
+            continue
+        record = param.get_help_record(ctx.parent)
+        if record is None:
+            continue
+        rows.append(record)
+    if not rows or isinstance(command, click.Group):
+        rows.append(("--help", "Show help for command"))
+    return rows
+
+
+def _inherited_option_names(ctx: click.Context) -> set[str]:
+    if ctx.parent is None:
+        return set()
+    names: set[str] = set()
+    for param in ctx.parent.command.get_params(ctx.parent):
+        if not isinstance(param, click.Option) or param.hidden:
+            continue
+        names.update(param.opts)
+        names.update(param.secondary_opts)
+    return names
+
+
+def _definition_section(title: str, rows: list[tuple[str, str]]) -> str:
+    width = max(len(left) for left, _ in rows) + 2
+    body = "\n".join(f"  {left.ljust(width)}{right}".rstrip() for left, right in rows)
+    return f"{title}\n{body}"
+
+
+def _argument_section(argument_help: str | list[str]) -> str:
+    if isinstance(argument_help, str):
+        body = "\n".join(f"  {line}" for line in argument_help.splitlines())
+    else:
+        body = "\n".join(f"  {line}" for line in argument_help)
+    return f"ARGUMENTS\n{body}"
+
+
+def _wrapped_list_section(title: str, values: list[str]) -> str:
+    body = textwrap.fill(
+        ", ".join(values),
+        width=78,
+        initial_indent="  ",
+        subsequent_indent="  ",
+    )
+    return f"{title}\n{body}"
+
+
+def _clean_text(value: str | None) -> str:
+    if not value:
+        return ""
+    return textwrap.dedent(value).strip()
+
+
+def _first_line(value: str | None) -> str:
+    text = _clean_text(value)
+    return text.splitlines()[0] if text else ""

--- a/src/gitcode_cli/helptext.py
+++ b/src/gitcode_cli/helptext.py
@@ -85,7 +85,7 @@ def _usage_line(command: click.Command, ctx: click.Context) -> str:
     else:
         for param in command.get_params(ctx):
             if isinstance(param, click.Argument):
-                pieces.append(param.make_metavar(ctx))
+                pieces.append(_argument_metavar(param, ctx))
     if any(isinstance(param, click.Option) and not param.hidden for param in command.get_params(ctx)):
         pieces.append("[flags]")
     return " ".join(piece for piece in pieces if piece)
@@ -97,6 +97,14 @@ def _display_command_path(ctx: click.Context) -> str:
         return "gc"
     parts[0] = "gc"
     return " ".join(parts)
+
+
+def _argument_metavar(param: click.Argument, ctx: click.Context) -> str:
+    make_metavar = param.make_metavar
+    try:
+        return make_metavar(ctx)
+    except TypeError:
+        return str(getattr(param, "metavar", None) or param.name or "")
 
 
 def _command_sections(command: click.Group) -> list[tuple[str, list[tuple[str, str]]]]:

--- a/src/gitcode_cli/helptext.py
+++ b/src/gitcode_cli/helptext.py
@@ -156,17 +156,18 @@ def _inherited_flag_rows(command: click.Command, ctx: click.Context) -> list[tup
     rows: list[tuple[str, str]] = []
     if ctx.parent is None:
         return rows
-    for param in ctx.parent.command.get_params(ctx.parent):
-        if not isinstance(param, click.Option) or param.hidden:
-            continue
-        if "--help" in param.opts or "-h" in param.opts:
-            continue
-        if "--version" in param.opts:
-            continue
-        record = param.get_help_record(ctx.parent)
-        if record is None:
-            continue
-        rows.append(record)
+    if not isinstance(command, click.Group):
+        for param in ctx.parent.command.get_params(ctx.parent):
+            if not isinstance(param, click.Option) or param.hidden:
+                continue
+            if "--help" in param.opts or "-h" in param.opts:
+                continue
+            if "--version" in param.opts:
+                continue
+            record = param.get_help_record(ctx.parent)
+            if record is None:
+                continue
+            rows.append(record)
     if not rows or isinstance(command, click.Group):
         rows.append(("--help", "Show help for command"))
     return rows

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -23,24 +23,28 @@ class TestCli:
     def test_cli_help(self, runner):
         result = runner.invoke(main, ["--help"])
         assert result.exit_code == 0
-        assert "Usage:" in result.output
+        assert "USAGE" in result.output
+        assert "CORE COMMANDS" in result.output
 
     def test_cli_issue_group(self, runner):
         result = runner.invoke(main, ["issue", "--help"])
         assert result.exit_code == 0
-        assert "Usage:" in result.output
+        assert "USAGE" in result.output
+        assert "GENERAL COMMANDS" in result.output
         assert "list" in result.output
 
     def test_cli_pr_group(self, runner):
         result = runner.invoke(main, ["pr", "--help"])
         assert result.exit_code == 0
-        assert "Usage:" in result.output
+        assert "USAGE" in result.output
+        assert "GENERAL COMMANDS" in result.output
         assert "list" in result.output
 
     def test_cli_auth_group(self, runner):
         result = runner.invoke(main, ["auth", "--help"])
         assert result.exit_code == 0
-        assert "Usage:" in result.output
+        assert "USAGE" in result.output
+        assert "COMMANDS" in result.output
         assert "login" in result.output
 
     def test_cli_with_token(self, runner, monkeypatch):


### PR DESCRIPTION
## Description

Align `gc` help output with the sectioned style used by `gh`, including root command help and the `auth`, `issue`, and `pr` command groups.

## Related Issue

Closes #76

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [ ] Test coverage remains >= 90%

Targeted validation run in the worktree:
- `conda run -n gitcode-cli python -m pytest tests/unit/test_cli.py tests/unit/commands/test_auth.py tests/unit/commands/test_issue.py tests/unit/commands/test_pr.py tests/unit/commands/test_cli_gh_compat.py -q --no-cov`
- Result: `196 passed`

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [ ] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide