### PR TITLE
ci: automate GitHub releases after PyPI publish

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -1,0 +1,84 @@
+name: Publish dev build to TestPyPI
+
+on:
+  push:
+    tags:
+      - "dev*"
+
+jobs:
+  build-and-publish:
+    name: Build and publish dev build to TestPyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/pygitcode
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine dev version
+        id: version
+        run: |
+          python - <<'PY'
+          from datetime import datetime, timezone
+          import os
+          import re
+          import subprocess
+
+          tag = "${{ github.ref_name }}"
+          commit_hash = tag.removeprefix("dev")
+          if not commit_hash:
+              raise SystemExit("Tag must be in the form dev<commit-hash>")
+          if not re.fullmatch(r"[0-9a-fA-F]+", commit_hash):
+              raise SystemExit("Commit hash in tag must be hexadecimal")
+
+          latest_tag = subprocess.check_output(
+              ["git", "tag", "--list", "v*", "--sort=-version:refname"],
+              text=True,
+          ).splitlines()
+          if not latest_tag:
+              raise SystemExit("No version tags matching v* found")
+
+          latest_version = latest_tag[0].removeprefix("v")
+          match = re.match(r"^(\d+(?:\.\d+)*)", latest_version)
+          if match is None:
+              raise SystemExit(f"Could not extract numeric version from tag {latest_tag[0]}")
+
+          base_version = match.group(1)
+          daily = datetime.now(timezone.utc).strftime("%Y%m%d")
+          version = f"{base_version}.dev{daily}+{commit_hash.lower()}"
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"VERSION={version}\n")
+              fh.write(f"BASE_VERSION={base_version}\n")
+              fh.write(f"COMMIT_HASH={commit_hash.lower()}\n")
+          PY
+
+      - name: Write version to __init__.py
+        run: |
+          sed -i 's/^__version__ = .*/__version__ = "'"${{ steps.version.outputs.VERSION }}"'"/' src/gitcode_cli/__init__.py
+          echo "Updated __init__.py:"
+          cat src/gitcode_cli/__init__.py
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,35 @@ jobs:
         id: version
         run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Validate changelog entry
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import re
+
+          version = "${{ steps.version.outputs.VERSION }}"
+          lines = Path("CHANGELOG.md").read_text(encoding="utf-8").splitlines()
+          pattern = re.compile(rf"^## \[{re.escape(version)}\]\b")
+
+          start = None
+          for i, line in enumerate(lines):
+              if pattern.match(line):
+                  start = i + 1
+                  break
+          if start is None:
+              raise SystemExit(f"Version {version} not found in CHANGELOG.md")
+
+          end = len(lines)
+          for i in range(start, len(lines)):
+              if lines[i].startswith("## "):
+                  end = i
+                  break
+
+          body = "\n".join(lines[start:end]).strip()
+          if not body:
+              raise SystemExit(f"No release notes found for version {version} in CHANGELOG.md")
+          PY
+
       - name: Write version to __init__.py
         run: |
           sed -i 's/^__version__ = .*/__version__ = "'"${{ steps.version.outputs.VERSION }}"'"/' src/gitcode_cli/__init__.py
@@ -44,3 +73,56 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: build-and-publish
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract release notes from changelog
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import re
+
+          version = "${{ steps.version.outputs.VERSION }}"
+          lines = Path("CHANGELOG.md").read_text(encoding="utf-8").splitlines()
+          pattern = re.compile(rf"^## \[{re.escape(version)}\]\b")
+
+          start = None
+          for i, line in enumerate(lines):
+              if pattern.match(line):
+                  start = i + 1
+                  break
+          if start is None:
+              raise SystemExit(f"Version {version} not found in CHANGELOG.md")
+
+          end = len(lines)
+          for i in range(start, len(lines)):
+              if lines[i].startswith("## "):
+                  end = i
+                  break
+
+          body = "\n".join(lines[start:end]).strip()
+          if not body:
+              raise SystemExit(f"No release notes found for version {version} in CHANGELOG.md")
+
+          Path("RELEASE_NOTES.md").write_text(body + "\n", encoding="utf-8")
+          PY
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body_path: RELEASE_NOTES.md


### PR DESCRIPTION
## Description

Automate GitHub Release creation from `CHANGELOG.md` after a tagged PyPI publish succeeds, and add a separate TestPyPI dev publish workflow for `dev<commit-hash>` tags.

## Related Issue

<!-- Link to the issue this PR addresses, e.g. Fixes #123 / Closes #456 -->

## Type of Change

<!-- Mark the relevant option with an \"x\" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [x] CI/Build improvement

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes -->

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [ ] Lint passes (`python -m ruff check src/ tests/`)
- [ ] Format passes (`python -m ruff format --check src/ tests/`)
- [ ] Type check passes (`python -m basedpyright src/`)
- [ ] Test coverage remains >= 90%

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [ ] I have added tests that prove my fix/feature works
- [ ] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide

## Notes

- The release workflow now validates the tagged changelog entry before publishing to PyPI.
- GitHub Release creation runs in a separate downstream job so release failures can be retried without republishing the package.
- A new `publish-dev.yml` workflow publishes `dev<commit-hash>` tags to TestPyPI using `<latest-numeric-version>.devYYYYMMDD+<commit-hash>` and does not create a GitHub Release.
- I also updated `.claude/pypi-release-process.md` locally to reflect the new automation, but `.claude/` is gitignored so that doc change is not included in this PR.