### PR TITLE
fix: match versioned changelog headings in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
 
           version = "${{ steps.version.outputs.VERSION }}"
           lines = Path("CHANGELOG.md").read_text(encoding="utf-8").splitlines()
-          pattern = re.compile(rf"^## \[{re.escape(version)}\]\b")
+          pattern = re.compile(rf"^## \[{re.escape(version)}\](?:\s|$)")
 
           start = None
           for i, line in enumerate(lines):
@@ -97,7 +97,7 @@ jobs:
 
           version = "${{ steps.version.outputs.VERSION }}"
           lines = Path("CHANGELOG.md").read_text(encoding="utf-8").splitlines()
-          pattern = re.compile(rf"^## \[{re.escape(version)}\]\b")
+          pattern = re.compile(rf"^## \[{re.escape(version)}\](?:\s|$)")
 
           start = None
           for i, line in enumerate(lines):


### PR DESCRIPTION
## Summary
- fix the publish workflow changelog heading regex
- allow headings like `## [0.1.2] - YYYY-MM-DD` to match correctly
- unblock tag-triggered release note validation and GitHub Release creation

## Test plan
- [x] confirm both changelog extraction sites use the same corrected regex
- [x] confirm only `.github/workflows/publish.yml` changed
- [x] pass local commit hooks