### PR TITLE
feat: support deleting issues from gc

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ gc issue edit 42 --milestone v1.0 --remove-milestone
 gc issue comment 42 -b "Thanks for the report!"
 gc issue comment 42 --editor    # Use system editor
 
-gc issue delete 42              # Exposed for gh parity; GitCode API may reject deletion
+gc issue delete 42              # Delete an issue (prompts by default)
+gc issue delete 42 --yes        # Skip confirmation
 
 # Close / reopen
 gc issue close 42
@@ -216,7 +217,7 @@ gc pr view -w
 
 - **PR comment model**: GitCode uses `path + position`, not GitHub's `line/side/commit`
 - **PR review**: GitCode review API differs from GitHub; `--request-changes` falls back to PR comments
-- **Issue deletion**: `gc issue delete` is exposed for CLI parity, but GitCode API does not support deleting issues
+- **Issue deletion**: `gc issue delete` relies on GitCode issue deletion support that is not currently documented in the public API; behavior may change if GitCode adjusts this endpoint
 - **Issue create/update API**: GitCode puts `repo` in request body, not URL path
 
 ## License

--- a/src/gitcode_cli/adapters/capabilities.py
+++ b/src/gitcode_cli/adapters/capabilities.py
@@ -8,7 +8,6 @@ CAPABILITY_MESSAGES = {
         "Unable to verify the current user's issue comments on GitCode; refusing to edit or delete comments safely."
     ),
     "ISSUE_CREATE_IF_NONE_REQUIRES_EDIT_LAST": "--create-if-none can only be used together with --edit-last.",
-    "ISSUE_DELETE": "GitCode API does not support deleting issues.",
     "ISSUE_DEVELOP_BASE": "--base and --name are not supported by 'gc issue develop'",
     "ISSUE_DEVELOP_NAME": "--base and --name are not supported by 'gc issue develop'",
     "ISSUE_STATUS_GH_SEMANTICS": "GitCode-limited approximation of gh issue status",

--- a/src/gitcode_cli/adapters/issues.py
+++ b/src/gitcode_cli/adapters/issues.py
@@ -181,8 +181,9 @@ class IssueAdapter:
         item = self.service.update(owner, repo, number, state="reopen")
         return AdapterActionResult(item=item, message="reopened")
 
-    def delete_issue(self, owner: str, repo: str, number: str) -> AdapterActionResult:  # noqa: ARG002
-        raise unsupported("ISSUE_DELETE")
+    def delete_issue(self, owner: str, repo: str, number: str) -> AdapterActionResult:
+        item = self.service.delete(owner, repo, number)
+        return AdapterActionResult(item=item, message="deleted")
 
     def edit_issue(
         self,

--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -460,9 +460,10 @@ def issue_edit(
 
 @issue_group.command("delete")
 @click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("--yes", is_flag=True, help="Skip the confirmation prompt.")
 @click.argument("identifier")
 @click.pass_context
-def issue_delete(ctx: click.Context, repo_name: str | None, identifier: str) -> None:
+def issue_delete(ctx: click.Context, repo_name: str | None, identifier: str, yes: bool) -> None:
     app = ctx.obj["app"]
     url_owner, url_repo, number = resolve_issue_arg(identifier)
     if url_owner:
@@ -471,9 +472,12 @@ def issue_delete(ctx: click.Context, repo_name: str | None, identifier: str) -> 
     else:
         owner, repo = resolve_repo(repo_name or app.repo)
         number = require_issue_number(identifier)
+    if not yes and not click.confirm(f"Delete issue #{number}?", default=False):
+        raise click.ClickException("Aborted.")
     service = IssueService(app.client())
     adapter = IssueAdapter(service)
     adapter.delete_issue(owner, repo, number)
+    safe_echo(f"Deleted issue #{number}")
 
 
 @issue_group.command("status")

--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -465,19 +465,14 @@ def issue_edit(
 @click.pass_context
 def issue_delete(ctx: click.Context, repo_name: str | None, identifier: str, yes: bool) -> None:
     app = ctx.obj["app"]
-    url_owner, url_repo, number = resolve_issue_arg(identifier)
-    if url_owner:
-        assert url_repo is not None
-        owner, repo = url_owner, url_repo
-    else:
-        owner, repo = resolve_repo(repo_name or app.repo)
-        number = require_issue_number(identifier)
-    if not yes and not click.confirm(f"Delete issue #{number}?", default=False):
+    owner, repo, number, _ = _resolve_issue_target(app, repo_name, identifier)
+    target = f"{owner}/{repo}#{number}"
+    if not yes and not click.confirm(f"Delete issue {target}?", default=False):
         raise click.ClickException("Aborted.")
     service = IssueService(app.client())
     adapter = IssueAdapter(service)
     adapter.delete_issue(owner, repo, number)
-    safe_echo(f"Deleted issue #{number}")
+    safe_echo(f"Deleted issue {target}")
 
 
 @issue_group.command("status")

--- a/src/gitcode_cli/services/issues.py
+++ b/src/gitcode_cli/services/issues.py
@@ -26,6 +26,9 @@ class IssueService:
         payload: dict[str, Any] = {"repo": repo, **{k: v for k, v in data.items() if v is not None}}
         return self.client.patch(f"/repos/{owner}/issues/{number}", json=payload)
 
+    def delete(self, owner: str, repo: str, number: str) -> Any | None:
+        return self.client.delete(f"/repos/{owner}/{repo}/issues/{number}")
+
     def comment(self, owner: str, repo: str, number: str, body: str) -> Any | None:
         return self.client.post(f"/repos/{owner}/{repo}/issues/{number}/comments", json={"body": body})
 

--- a/tests/unit/adapters/test_issue_adapter.py
+++ b/tests/unit/adapters/test_issue_adapter.py
@@ -73,6 +73,15 @@ class TestIssueAdapter:
             milestone="v1",
         )
 
+    def test_delete_issue_calls_service_delete(self, adapter, service):
+        service.delete.return_value = {"success": True}
+
+        result = adapter.delete_issue("owner", "repo", "42")
+
+        service.delete.assert_called_once_with("owner", "repo", "42")
+        assert result.item == {"success": True}
+        assert result.message == "deleted"
+
     def test_manage_comment_history_edits_last_owned_comment(self, adapter, service, user_service):
         user_service.current.return_value = {"login": "alice"}
         service.list_comments.return_value = [

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -590,17 +590,23 @@ class TestIssueEdit:
 
 
 class TestIssueDelete:
-    def test_default_returns_clear_unsupported_error(self, runner, mock_client, mock_repo):
-        result = runner.invoke(main, ["issue", "delete", "42"])
+    def test_delete_requires_confirmation_by_default(self, runner, mock_client, mock_repo):
+        result = runner.invoke(main, ["issue", "delete", "42"], input="n\n")
         assert result.exit_code != 0
-        assert "GitCode API does not support deleting issues." in result.output
+        assert "Aborted." in result.output
         mock_client.delete.assert_not_called()
 
-    def test_url_returns_clear_unsupported_error(self, runner, mock_client):
-        result = runner.invoke(main, ["issue", "delete", "https://gitcode.com/owner/repo/issues/42"])
-        assert result.exit_code != 0
-        assert "GitCode API does not support deleting issues." in result.output
-        mock_client.delete.assert_not_called()
+    def test_delete_yes_skips_confirmation(self, runner, mock_client, mock_repo):
+        result = runner.invoke(main, ["issue", "delete", "42", "--yes"])
+        assert result.exit_code == 0
+        assert "Deleted issue #42" in result.output
+        mock_client.delete.assert_called_once_with("/repos/owner/repo/issues/42")
+
+    def test_delete_url_yes_skips_confirmation(self, runner, mock_client):
+        result = runner.invoke(main, ["issue", "delete", "https://gitcode.com/owner/repo/issues/42", "--yes"])
+        assert result.exit_code == 0
+        assert "Deleted issue #42" in result.output
+        mock_client.delete.assert_called_once_with("/repos/owner/repo/issues/42")
 
 
 class TestIssueDevelop:

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -593,19 +593,20 @@ class TestIssueDelete:
     def test_delete_requires_confirmation_by_default(self, runner, mock_client, mock_repo):
         result = runner.invoke(main, ["issue", "delete", "42"], input="n\n")
         assert result.exit_code != 0
+        assert "Delete issue owner/repo#42?" in result.output
         assert "Aborted." in result.output
         mock_client.delete.assert_not_called()
 
     def test_delete_yes_skips_confirmation(self, runner, mock_client, mock_repo):
         result = runner.invoke(main, ["issue", "delete", "42", "--yes"])
         assert result.exit_code == 0
-        assert "Deleted issue #42" in result.output
+        assert "Deleted issue owner/repo#42" in result.output
         mock_client.delete.assert_called_once_with("/repos/owner/repo/issues/42")
 
     def test_delete_url_yes_skips_confirmation(self, runner, mock_client):
         result = runner.invoke(main, ["issue", "delete", "https://gitcode.com/owner/repo/issues/42", "--yes"])
         assert result.exit_code == 0
-        assert "Deleted issue #42" in result.output
+        assert "Deleted issue owner/repo#42" in result.output
         mock_client.delete.assert_called_once_with("/repos/owner/repo/issues/42")
 
 

--- a/tests/unit/services/test_issues.py
+++ b/tests/unit/services/test_issues.py
@@ -54,6 +54,13 @@ class TestIssueService:
         )
         assert result == {"number": "42"}
 
+    def test_delete(self, service, mock_client):
+        mock_client.delete.return_value = {"success": True}
+        result = service.delete("owner", "repo", "42")
+
+        mock_client.delete.assert_called_once_with("/repos/owner/repo/issues/42")
+        assert result == {"success": True}
+
     def test_comment(self, service, mock_client):
         mock_client.post.return_value = {"id": 1}
         result = service.comment("owner", "repo", "42", "Nice issue!")


### PR DESCRIPTION
## Description

Implements `gc issue delete` using GitCode's hidden issue deletion endpoint and adds a confirmation flow with `--yes` support.

## Related Issue

Fixes #82

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`conda run -n gitcode-cli pytest --override-ini addopts='' tests/unit/services/test_issues.py tests/unit/adapters/test_issue_adapter.py tests/unit/commands/test_issue.py -k "test_delete or IssueDelete or delete_last_yes_skips_confirmation or delete_last_requires_confirmation_by_default"`)
- [x] Lint passes (`ruff`, via pre-commit hook during commit)
- [x] Format passes (`ruff-format`, via pre-commit hook during commit)
- [x] Type check passes (`basedpyright`, via pre-commit hook during commit)
- [x] Test coverage remains >= 90% (`pytest`, via pre-commit hook during commit)

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide