### PR TITLE
Mark unsupported gh-compatible flags

### DIFF
--- a/src/gitcode_cli/adapters/capabilities.py
+++ b/src/gitcode_cli/adapters/capabilities.py
@@ -10,6 +10,7 @@ CAPABILITY_MESSAGES = {
     "ISSUE_CREATE_IF_NONE_REQUIRES_EDIT_LAST": "--create-if-none can only be used together with --edit-last.",
     "ISSUE_DEVELOP_BASE": "--base and --name are not supported by 'gc issue develop'",
     "ISSUE_DEVELOP_NAME": "--base and --name are not supported by 'gc issue develop'",
+    "ISSUE_LIST_APP": "GitCode issue API does not support --app filtering.",
     "ISSUE_STATUS_GH_SEMANTICS": "GitCode-limited approximation of gh issue status",
     "PR_MERGE_AUTHOR_EMAIL": "GitCode merge API does not support --author-email.",
     "PR_MERGE_AUTO": "GitCode merge API does not support --auto.",

--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import click
 
 from ..adapters import IssueAdapter
-from ..adapters.capabilities import capability_message
+from ..adapters.capabilities import capability_message, unsupported
 from ..cli_compat import get_body_from_options
 from ..formatters import format_issue_detail, format_issue_list, output_result
 from ..helptext import GCSectionGroup, set_gc_help
@@ -127,7 +127,7 @@ def issue_list(
     if limit is not None and limit < 1:
         raise click.BadParameter("must be greater than 0", param_hint="--limit")
     if app is not None:
-        _pending_gh_compat("issue list --app")
+        raise unsupported("ISSUE_LIST_APP")
     if web:
         open_in_browser(f"https://gitcode.com/{owner}/{repo}/issues")
         return

--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -6,6 +6,7 @@ import subprocess
 import click
 
 from ..adapters import PullRequestAdapter
+from ..adapters.capabilities import unsupported
 from ..cli_compat import (
     get_body_from_options,
     get_default_base_branch,
@@ -68,9 +69,9 @@ def pr_merge(
     app = ctx.obj["app"]
     owner, repo = resolve_repo(repo_name or app.repo)
     if author_email is not None:
-        raise click.ClickException("GitCode merge API does not support --author-email.")
+        raise unsupported("PR_MERGE_AUTHOR_EMAIL")
     if auto:
-        raise click.ClickException("GitCode merge API does not support --auto.")
+        raise unsupported("PR_MERGE_AUTO")
     service = PullRequestService(app.client())
     resolved_identifier = resolve_pr_identifier_or_current_branch(identifier)
     owner, repo, number = resolve_pr_arg(resolved_identifier, owner, repo, service)

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -130,6 +130,13 @@ class TestIssueList:
         assert "Maximum number of items to fetch." in result.output
         assert "[default:" in result.output
 
+    def test_list_app_remains_unsupported(self, runner, mock_client, mock_repo):
+        result = runner.invoke(main, ["issue", "list", "--app", "github-actions"])
+        assert result.exit_code != 0
+        assert "GitCode issue API does not support --app filtering." in result.output
+        assert "recognized but not implemented" not in result.output
+        mock_client.get.assert_not_called()
+
     def test_rejects_zero_limit(self, runner, mock_client, mock_repo):
         result = runner.invoke(main, ["issue", "list", "-L", "0"])
         assert result.exit_code != 0

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -486,13 +486,13 @@ class TestPrMerge:
     def test_pr_merge_author_email_remains_unsupported(self, runner, mock_client, mock_repo):
         result = runner.invoke(main, ["pr", "merge", "42", "--author-email", "a@example.com"])
         assert result.exit_code != 0
-        assert "does not support --author-email" in result.output
+        assert "GitCode merge API does not support --author-email." in result.output
         mock_client.put.assert_not_called()
 
     def test_pr_merge_auto_remains_unsupported(self, runner, mock_client, mock_repo):
         result = runner.invoke(main, ["pr", "merge", "42", "--auto"])
         assert result.exit_code != 0
-        assert "does not support --auto" in result.output
+        assert "GitCode merge API does not support --auto." in result.output
         mock_client.put.assert_not_called()
 
     def test_pr_comment(self, runner, mock_client, mock_repo):


### PR DESCRIPTION
## Description

Marks the remaining recognized-but-unimplementable gh-compatible flags as explicit GitCode unsupported capabilities:

- `gc issue list --app`
- `gc pr merge --author-email`
- `gc pr merge --auto`

The PR keeps these flags parseable and routes their failure messages through centralized capability messages.

## Related Issue

Fixes #85

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

Additional verification:

- `conda run -n gitcode-cli pytest` (`407 passed`, coverage `92.29%`)
- Pre-commit hook passed: ruff, ruff-format, basedpyright, pytest

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide