### PR TITLE
Support duplicate issue close approximation

### DIFF
--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -280,7 +280,7 @@ def issue_create(
 @click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier")
 @click.option("-c", "--comment", help="Leave a closing comment.")
-@click.option("--duplicate-of")
+@click.option("--duplicate-of", help="Close as a GitCode-limited duplicate approximation by posting a comment first.")
 @click.option("-r", "--reason", type=click.Choice(["completed", "not_planned"]), help="Reason for closing.")
 @click.pass_context
 def issue_close(
@@ -299,18 +299,27 @@ def issue_close(
     else:
         owner, repo = resolve_repo(repo_name or app.repo)
         number = require_issue_number(identifier)
+    approximated = duplicate_of is not None
     if duplicate_of is not None:
-        _pending_gh_compat("issue close --duplicate-of")
+        duplicate_comment = f"This issue is considered a duplicate of {duplicate_of}."
+        comment = f"{comment}\n\n{duplicate_comment}" if comment else duplicate_comment
     service = IssueService(app.client())
     adapter = IssueAdapter(service)
     result = adapter.close_issue(owner, repo, number, comment=comment, reason=reason)
+    approximation_note = (
+        "Note: --duplicate-of is a GitCode-limited approximation; " "no native duplicate relationship was created."
+    )
     if result.message == "already_closed_commented":
         safe_echo(f"Issue #{safe_number(result.item, number)} is already closed; posted comment")
+        if approximated:
+            safe_echo(approximation_note)
         return
     if result.message == "already_closed":
         safe_echo(f"Issue #{safe_number(result.item, number)} is already closed")
         return
     safe_echo(f"Closed issue #{safe_number(result.item, number)}")
+    if approximated:
+        safe_echo(approximation_note)
 
 
 @issue_group.command("comment")

--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -307,7 +307,7 @@ def issue_close(
     adapter = IssueAdapter(service)
     result = adapter.close_issue(owner, repo, number, comment=comment, reason=reason)
     approximation_note = (
-        "Note: --duplicate-of is a GitCode-limited approximation; " "no native duplicate relationship was created."
+        "Note: --duplicate-of is a GitCode-limited approximation; no native duplicate relationship was created."
     )
     if result.message == "already_closed_commented":
         safe_echo(f"Issue #{safe_number(result.item, number)} is already closed; posted comment")

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -357,6 +357,53 @@ class TestIssueClose:
         assert result.exit_code == 0
         assert "Closed issue #42" in result.output
 
+    def test_close_duplicate_of_posts_comment_then_closes_with_approximation_note(self, runner, mock_client, mock_repo):
+        mock_client.get.return_value = {"number": "42", "state": "open"}
+        mock_client.patch.return_value = {"number": "42", "state": "closed"}
+
+        result = runner.invoke(main, ["issue", "close", "42", "--duplicate-of", "12"])
+
+        assert result.exit_code == 0
+        assert "Closed issue #42" in result.output
+        assert "GitCode-limited approximation" in result.output
+        mock_client.post.assert_called_once_with(
+            "/repos/owner/repo/issues/42/comments",
+            json={"body": "This issue is considered a duplicate of 12."},
+        )
+        mock_client.patch.assert_called_once()
+        assert mock_client.method_calls == [
+            call.get("/repos/owner/repo/issues/42"),
+            call.post(
+                "/repos/owner/repo/issues/42/comments",
+                json={"body": "This issue is considered a duplicate of 12."},
+            ),
+            call.patch("/repos/owner/issues/42", json={"repo": "repo", "state": "close"}),
+        ]
+
+    def test_close_duplicate_of_preserves_comment_and_reason(self, runner, mock_client, mock_repo):
+        mock_client.get.return_value = {"number": "42", "state": "open"}
+        mock_client.patch.return_value = {"number": "42", "state": "closed"}
+
+        result = runner.invoke(
+            main,
+            ["issue", "close", "42", "--duplicate-of", "12", "--comment", "Superseded", "--reason", "not_planned"],
+        )
+
+        assert result.exit_code == 0
+        mock_client.post.assert_called_once_with(
+            "/repos/owner/repo/issues/42/comments",
+            json={"body": "Superseded\n\nThis issue is considered a duplicate of 12."},
+        )
+        patch_kwargs = mock_client.patch.call_args.kwargs
+        assert patch_kwargs["json"]["state_reason"] == "not_planned"
+
+    def test_close_duplicate_of_help_describes_approximation(self, runner):
+        result = runner.invoke(main, ["issue", "close", "--help"])
+
+        assert result.exit_code == 0
+        assert "GitCode-limited duplicate approximation" in result.output
+        assert "native duplicate" not in result.output.lower()
+
     def test_close_rejects_non_numeric_identifier(self, runner, mock_client, mock_repo):
         result = runner.invoke(main, ["issue", "close", "not-a-number"])
         assert result.exit_code != 0


### PR DESCRIPTION
## Description

Implement `gc issue close --duplicate-of` as a GitCode-limited approximation: the command posts a duplicate notice comment, preserves compatible `--comment` / `--reason` behavior, then closes the issue through the existing close flow.

## Related Issue

Closes #84

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

Additional local verification:

- `conda run -n gitcode-cli pytest --no-cov`
- Pre-commit hooks: `ruff`, `ruff-format`, `basedpyright`, `pytest`

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide