### PR TITLE
Add pending guards for gh-compatible options

### DIFF
--- a/src/gitcode_cli/commands/auth.py
+++ b/src/gitcode_cli/commands/auth.py
@@ -7,6 +7,10 @@ from ..helptext import GCSectionGroup
 from ..utils import safe_echo
 
 
+def _pending_gh_compat(name: str) -> None:
+    raise click.ClickException(f"gh-compatible command/flag '{name}' is recognized but not implemented yet.")
+
+
 @click.group("auth", cls=GCSectionGroup, help="Authenticate gc with GitCode.")
 def auth_group() -> None:
     pass
@@ -36,7 +40,16 @@ def auth_logout() -> None:
 
 
 @auth_group.command("status", short_help="Show authentication status", help="Show authentication status.")
-def auth_status() -> None:
+@click.option("--json", "json_fields")
+@click.option("-q", "--jq", "jq_query")
+@click.option("-t", "--template")
+def auth_status(json_fields: str | None, jq_query: str | None, template: str | None) -> None:
+    if json_fields is not None:
+        _pending_gh_compat("auth status --json")
+    if jq_query is not None:
+        _pending_gh_compat("auth status --jq")
+    if template is not None:
+        _pending_gh_compat("auth status --template")
     try:
         token = get_token()
     except Exception:

--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -380,8 +380,11 @@ def issue_comment(
 @issue_group.command("reopen")
 @click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier")
+@click.option("-c", "--comment")
 @click.pass_context
-def issue_reopen(ctx: click.Context, repo_name: str | None, identifier: str) -> None:
+def issue_reopen(ctx: click.Context, repo_name: str | None, identifier: str, comment: str | None) -> None:
+    if comment is not None:
+        _pending_gh_compat("issue reopen --comment")
     app = ctx.obj["app"]
     url_owner, url_repo, number = resolve_issue_arg(identifier)
     if url_owner:
@@ -408,6 +411,8 @@ def issue_reopen(ctx: click.Context, repo_name: str | None, identifier: str) -> 
 @click.option("-a", "--add-assignee")
 @click.option("-l", "--add-label", "add_labels", multiple=True)
 @click.option("-m", "--milestone")
+@click.option("--remove-assignee")
+@click.option("--remove-label", "remove_labels", multiple=True)
 @click.option("--remove-milestone", is_flag=True, help="Remove the milestone from the issue.")
 @click.pass_context
 def issue_edit(
@@ -420,8 +425,14 @@ def issue_edit(
     add_assignee: str | None,
     add_labels: tuple[str, ...] | None,
     milestone: str | None,
+    remove_assignee: str | None,
+    remove_labels: tuple[str, ...] | None,
     remove_milestone: bool,
 ) -> None:
+    if remove_assignee is not None:
+        _pending_gh_compat("issue edit --remove-assignee")
+    if remove_labels:
+        _pending_gh_compat("issue edit --remove-label")
     app = ctx.obj["app"]
     url_owner, url_repo, number = resolve_issue_arg(identifier)
     if url_owner:
@@ -438,6 +449,8 @@ def issue_edit(
             add_assignee is not None,
             add_labels,
             milestone is not None,
+            remove_assignee is not None,
+            remove_labels,
             remove_milestone,
         ]
     ):

--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -101,10 +101,14 @@ def pr_merge(
 @click.argument("identifier", required=False)
 @click.option("-b", "--body")
 @click.option("-F", "--body-file")
+@click.option("--create-if-none", is_flag=True)
+@click.option("--delete-last", is_flag=True)
+@click.option("--edit-last", is_flag=True)
 @click.option("-e", "--editor", is_flag=True)
 @click.option("-w", "--web", is_flag=True, help="Open the pull request in the web browser.")
 @click.option("--path")
 @click.option("--position", type=int)
+@click.option("--yes", is_flag=True)
 @click.pass_context
 def pr_comment(
     ctx: click.Context,
@@ -112,11 +116,23 @@ def pr_comment(
     identifier: str | None,
     body: str | None,
     body_file: str | None,
+    create_if_none: bool,
+    delete_last: bool,
+    edit_last: bool,
     editor: bool,
     web: bool,
     path: str | None,
     position: int | None,
+    yes: bool,
 ) -> None:
+    if create_if_none:
+        _pending_gh_compat("pr comment --create-if-none")
+    if delete_last:
+        _pending_gh_compat("pr comment --delete-last")
+    if edit_last:
+        _pending_gh_compat("pr comment --edit-last")
+    if yes:
+        _pending_gh_compat("pr comment --yes")
     app = ctx.obj["app"]
     owner, repo = resolve_repo(repo_name or app.repo)
     service = PullRequestService(app.client())
@@ -190,8 +206,11 @@ def pr_review(
 @pr_group.command("reopen")
 @click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier", required=False)
+@click.option("-c", "--comment")
 @click.pass_context
-def pr_reopen(ctx: click.Context, repo_name: str | None, identifier: str | None) -> None:
+def pr_reopen(ctx: click.Context, repo_name: str | None, identifier: str | None, comment: str | None) -> None:
+    if comment is not None:
+        _pending_gh_compat("pr reopen --comment")
     app = ctx.obj["app"]
     owner, repo = resolve_repo(repo_name or app.repo)
     service = PullRequestService(app.client())
@@ -547,8 +566,14 @@ def pr_close(
 @pr_group.command("diff")
 @click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier", required=False)
+@click.option("--name-only", is_flag=True)
+@click.option("--patch", is_flag=True)
 @click.pass_context
-def pr_diff(ctx: click.Context, repo_name: str | None, identifier: str | None) -> None:
+def pr_diff(ctx: click.Context, repo_name: str | None, identifier: str | None, name_only: bool, patch: bool) -> None:
+    if name_only:
+        _pending_gh_compat("pr diff --name-only")
+    if patch:
+        _pending_gh_compat("pr diff --patch")
     app = ctx.obj["app"]
     owner, repo = resolve_repo(repo_name or app.repo)
     service = PullRequestService(app.client())
@@ -562,8 +587,21 @@ def pr_diff(ctx: click.Context, repo_name: str | None, identifier: str | None) -
 @click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier", required=False)
 @click.option("-b", "--branch", help="Local branch name to checkout into.")
+@click.option("--detach", is_flag=True)
+@click.option("-f", "--force", is_flag=True)
 @click.pass_context
-def pr_checkout(ctx: click.Context, repo_name: str | None, identifier: str | None, branch: str | None) -> None:
+def pr_checkout(
+    ctx: click.Context,
+    repo_name: str | None,
+    identifier: str | None,
+    branch: str | None,
+    detach: bool,
+    force: bool,
+) -> None:
+    if detach:
+        _pending_gh_compat("pr checkout --detach")
+    if force:
+        _pending_gh_compat("pr checkout --force")
     app = ctx.obj["app"]
     owner, repo = resolve_repo(repo_name or app.repo)
     service = PullRequestService(app.client())

--- a/tests/fixtures/gh-cli-compat/coverage.json
+++ b/tests/fixtures/gh-cli-compat/coverage.json
@@ -1,31 +1,47 @@
 {
   "groups": {
-    "issue": ["list", "view", "create", "close", "comment"],
-    "pr": ["list", "view", "create", "close", "merge", "comment", "review"]
+    "auth": ["status"],
+    "issue": ["list", "view", "create", "close", "comment", "edit", "reopen"],
+    "pr": ["list", "view", "create", "close", "merge", "comment", "review", "reopen", "diff", "checkout"]
   },
   "exclude_flags": {
+    "auth": {
+      "status": [
+        {"name": "--active", "reason": "active account selection is outside the selected #86 placeholder set"},
+        {"name": "-a", "reason": "active account selection is outside the selected #86 placeholder set"},
+        {"name": "--hostname", "reason": "multi-host auth status is outside the selected #86 placeholder set"},
+        {"name": "-h", "reason": "multi-host auth status is outside the selected #86 placeholder set"},
+        {"name": "--show-token", "reason": "token reveal is outside the selected #86 placeholder set"}
+      ]
+    },
     "issue": {
       "create": [
         {"name": "-p", "reason": "git protocol selection is not implemented by gc issue create"},
         {"name": "--recover", "reason": "draft recovery is not implemented by gc issue create"},
         {"name": "-T", "reason": "template selection is not implemented by gc issue create"}
       ],
+      "edit": [
+        {"name": "--add-project", "reason": "project association is outside the selected #86 placeholder set"},
+        {"name": "--remove-project", "reason": "project association is outside the selected #86 placeholder set"}
+      ],
       "list": [
         {"name": "-m", "reason": "gh short alias differs from gc, which only exposes --milestone"}
       ]
     },
     "pr": {
-      "comment": [
-        {"name": "--create-if-none", "reason": "comment history management is not implemented by gc pr comment"},
-        {"name": "--delete-last", "reason": "comment history management is not implemented by gc pr comment"},
-        {"name": "--edit-last", "reason": "comment history management is not implemented by gc pr comment"},
-        {"name": "--yes", "reason": "confirmation bypass for history-management flows is not implemented by gc pr comment"}
+      "checkout": [
+        {"name": "--recurse-submodules", "reason": "submodule checkout behavior is outside the selected #86 placeholder set"}
       ],
       "create": [
         {"name": "--no-maintainer-edit", "reason": "maintainer edit controls are not implemented by GitCode-backed PR creation"},
         {"name": "-p", "reason": "project selection is not implemented by gc pr create"},
         {"name": "--recover", "reason": "draft recovery is not implemented by gc pr create"},
         {"name": "-T", "reason": "template selection is not implemented by gc pr create"}
+      ],
+      "diff": [
+        {"name": "--color", "reason": "diff color rendering is outside the selected #86 placeholder set"},
+        {"name": "-e", "reason": "diff exclude filtering is outside the selected #86 placeholder set"},
+        {"name": "--web", "reason": "opening PR diff in browser is outside the selected #86 placeholder set"}
       ],
       "list": [
         {"name": "--app", "reason": "application filtering is not implemented by gc pr list"}

--- a/tests/unit/commands/test_cli_gh_compat.py
+++ b/tests/unit/commands/test_cli_gh_compat.py
@@ -162,6 +162,31 @@ class TestCliGhCompatibility:
     def test_command_has_gh_flags(self, command_path: str, expected_flags: list[tuple[str, ...]]) -> None:
         _assert_command_flags(command_path, expected_flags)
 
+    @pytest.mark.parametrize(
+        ("args", "flag_name"),
+        [
+            (["pr", "comment", "1", "--create-if-none"], "pr comment --create-if-none"),
+            (["pr", "comment", "1", "--delete-last"], "pr comment --delete-last"),
+            (["pr", "comment", "1", "--edit-last"], "pr comment --edit-last"),
+            (["pr", "comment", "1", "--yes"], "pr comment --yes"),
+            (["issue", "edit", "1", "--remove-assignee", "monalisa"], "issue edit --remove-assignee"),
+            (["issue", "edit", "1", "--remove-label", "bug"], "issue edit --remove-label"),
+            (["issue", "reopen", "1", "--comment", "reopening"], "issue reopen --comment"),
+            (["pr", "reopen", "1", "--comment", "reopening"], "pr reopen --comment"),
+            (["pr", "diff", "1", "--name-only"], "pr diff --name-only"),
+            (["pr", "diff", "1", "--patch"], "pr diff --patch"),
+            (["pr", "checkout", "1", "--detach"], "pr checkout --detach"),
+            (["pr", "checkout", "1", "--force"], "pr checkout --force"),
+            (["auth", "status", "--json", "token"], "auth status --json"),
+            (["auth", "status", "--jq", ".token"], "auth status --jq"),
+            (["auth", "status", "--template", "{{.token}}"], "auth status --template"),
+        ],
+    )
+    def test_selected_gh_flags_fail_as_pending(self, args: list[str], flag_name: str) -> None:
+        result = CliRunner().invoke(main, args)
+        assert result.exit_code != 0
+        assert f"gh-compatible command/flag '{flag_name}' is recognized but not implemented yet." in result.output
+
     def test_issue_list_rejects_invalid_limit(self) -> None:
         result = CliRunner().invoke(main, ["issue", "list", "-L", "0"])
         assert result.exit_code != 0


### PR DESCRIPTION
## Description

Adds Click-level placeholders for selected high-value `gh`-compatible options that were previously unknown to `gc`, returning explicit pending compatibility errors until behavior is implemented.

## Related Issue

Closes #86

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

Pre-commit also ran `ruff`, `ruff-format`, `basedpyright`, and `pytest` successfully during commit.

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide