### PR TITLE
Fix jq multi-item parsing in CLI fallback

### DIFF
--- a/src/gitcode_cli/formatters.py
+++ b/src/gitcode_cli/formatters.py
@@ -107,6 +107,15 @@ def format_pr_detail(item: dict) -> str:
     return _format_detail(item, author_keys=("user", "author", "creator"), branch=branch)
 
 
+def _parse_jq_output(stdout: str):
+    output = stdout.strip()
+    if not output:
+        return []
+    if output[0] == "[":
+        return json.loads(output)
+    return [json.loads(line) for line in output.splitlines()]
+
+
 def apply_jq(data, query: str):
     try:
         import jq  # noqa: PLC0415
@@ -123,7 +132,7 @@ def apply_jq(data, query: str):
             text=True,
             check=True,
         )
-        return json.loads(proc.stdout)
+        return _parse_jq_output(proc.stdout)
     raise click.ClickException("jq is required for --jq. Install with: pip install pyjq or install jq CLI.")
 
 

--- a/tests/unit/test_formatters.py
+++ b/tests/unit/test_formatters.py
@@ -229,6 +229,22 @@ class TestApplyJq:
         result = apply_jq({"id": 1}, ".id")
         assert result == [{"id": 1}]
 
+    def test_jq_cli_multiple_json_lines(self, mocker):
+        mocker.patch.dict("sys.modules", {"jq": None})
+        mock_run = mocker.patch("gitcode_cli.formatters.subprocess.run")
+        mock_run.return_value = MagicMock(stdout='{"id":1}\n{"id":2}\n')
+        mocker.patch("gitcode_cli.formatters.shutil.which", return_value="/usr/bin/jq")
+        result = apply_jq([{"id": 1}, {"id": 2}], ".[]")
+        assert result == [{"id": 1}, {"id": 2}]
+
+    def test_jq_cli_empty_output_returns_empty_list(self, mocker):
+        mocker.patch.dict("sys.modules", {"jq": None})
+        mock_run = mocker.patch("gitcode_cli.formatters.subprocess.run")
+        mock_run.return_value = MagicMock(stdout="\n")
+        mocker.patch("gitcode_cli.formatters.shutil.which", return_value="/usr/bin/jq")
+        result = apply_jq({"id": 1}, "empty")
+        assert result == []
+
     def test_jq_not_available_raises_click_exception(self, mocker):
         mocker.patch.dict("sys.modules", {"jq": None})
         mocker.patch("gitcode_cli.formatters.shutil.which", return_value=None)


### PR DESCRIPTION
## Description

Fix the jq CLI fallback so `-q/--jq` can handle multi-item results without crashing.

- parse jq CLI array output as JSON arrays
- parse newline-delimited jq CLI output as individual JSON values
- return an empty list when jq produces no output
- add regression tests for multi-line and empty jq CLI output

## Related Issue

Fixes #94

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [ ] Test coverage remains >= 90%

Validation run for this change:
- `conda run -n gitcode-cli pytest --no-cov tests/unit/test_formatters.py`
- `conda run -n gitcode-cli ruff check src/ tests/`
- `conda run -n gitcode-cli ruff format --check src/ tests/`
- `conda run -n gitcode-cli basedpyright src/`

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [ ] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide