### PR TITLE
Fix issue list @me author resolution

### DIFF
--- a/src/gitcode_cli/adapters/issues.py
+++ b/src/gitcode_cli/adapters/issues.py
@@ -70,6 +70,13 @@ class IssueAdapter:
         search: str | None,
         limit: int | None,
     ) -> Any:
+        if author == "@me":
+            if self.user_service is None:
+                raise click.ClickException("failed to resolve @me: current user lookup is unavailable")
+            current_login = _extract_login(self.user_service.current())
+            if not current_login:
+                raise click.ClickException("failed to resolve @me: current user has no login")
+            author = current_login
         items = self.service.list(
             owner,
             repo,

--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -133,7 +133,7 @@ def issue_list(
         open_in_browser(f"https://gitcode.com/{owner}/{repo}/issues")
         return
     service = IssueService(app_ctx.client())
-    adapter = IssueAdapter(service)
+    adapter = IssueAdapter(service, UserService(app_ctx.client()))
     items = adapter.list_issues(
         owner,
         repo,

--- a/tests/unit/adapters/test_issue_adapter.py
+++ b/tests/unit/adapters/test_issue_adapter.py
@@ -52,6 +52,36 @@ class TestIssueAdapter:
         )
         assert result == [{"number": "1"}]
 
+    def test_list_issues_resolves_author_me_to_current_login(self, adapter, service, user_service):
+        user_service.current.return_value = {"login": "alice"}
+        service.list.return_value = [{"number": "1"}]
+
+        adapter.list_issues(
+            "owner",
+            "repo",
+            state="open",
+            labels=None,
+            author="@me",
+            assignee=None,
+            milestone=None,
+            mention=None,
+            search=None,
+            limit=None,
+        )
+
+        user_service.current.assert_called_once_with()
+        service.list.assert_called_once_with(
+            "owner",
+            "repo",
+            state="open",
+            labels=None,
+            creator="alice",
+            assignee=None,
+            milestone=None,
+            mention=None,
+            search=None,
+        )
+
     def test_create_issue_normalizes_labels(self, adapter, service):
         adapter.create_issue(
             "owner",

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -100,6 +100,31 @@ class TestIssueList:
         mock_client.get.assert_not_called()
         mock_browser.assert_called_once_with("https://gitcode.com/owner/repo/issues")
 
+    def test_author_me_resolves_to_current_login(self, runner, mock_client, mock_repo):
+        mock_client.get.side_effect = [
+            {"login": "alice"},
+            [{"number": "1", "state": "open", "title": "First", "author": {"login": "alice"}}],
+        ]
+
+        result = runner.invoke(main, ["issue", "list", "--author", "@me"])
+
+        assert result.exit_code == 0
+        assert mock_client.get.call_args_list == [
+            call("/user"),
+            call(
+                "/repos/owner/repo/issues",
+                params={
+                    "state": None,
+                    "labels": None,
+                    "creator": "alice",
+                    "assignee": None,
+                    "milestone": None,
+                    "mention": None,
+                    "search": None,
+                },
+            ),
+        ]
+
     def test_json_fields(self, runner, mock_client, mock_repo):
         mock_client.get.return_value = [{"number": "1", "title": "T", "state": "open"}]
         result = runner.invoke(main, ["issue", "list", "--json", "number,title"])

--- a/tests/unit/commands/test_issue_adapter_boundary.py
+++ b/tests/unit/commands/test_issue_adapter_boundary.py
@@ -47,7 +47,9 @@ class TestIssueCommandAdapterBoundary:
 
         assert result.exit_code == 0
         issue_service_ctor.assert_called_once_with(mock_app_client)
-        issue_adapter_ctor.assert_called_once_with(issue_service_ctor.return_value)
+        issue_adapter_ctor.assert_called_once()
+        assert issue_adapter_ctor.call_args.args[0] is issue_service_ctor.return_value
+        assert issue_adapter_ctor.call_args.args[1].__class__.__name__ == "UserService"
         adapter.list_issues.assert_called_once_with(
             "owner",
             "repo",


### PR DESCRIPTION
## Description

Resolve `gc issue list --author @me` to the authenticated user's login before sending the `creator` filter to the GitCode API. This fixes the `user not found` error and aligns the flag with expected `gh`-style behavior.

## Related Issue

Fixes #93

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [ ] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide