### PR TITLE
Refine issue develop capability boundaries

### DIFF
--- a/src/gitcode_cli/adapters/issues.py
+++ b/src/gitcode_cli/adapters/issues.py
@@ -7,7 +7,7 @@ import click
 from ..errors import APIError
 from ..services import IssueService, UserService
 from .base import AdapterActionResult
-from .capabilities import capability_message, unsupported
+from .capabilities import capability_message
 
 
 def _normalize_multi_values(values: tuple[str, ...] | None) -> str | None:
@@ -230,10 +230,6 @@ class IssueAdapter:
         )
 
     def develop(self, owner: str, repo: str, number: str, *, base: str | None, name: str | None) -> AdapterActionResult:  # noqa: ARG002
-        if base is not None:
-            raise unsupported("ISSUE_DEVELOP_BASE")
-        if name is not None:
-            raise unsupported("ISSUE_DEVELOP_NAME")
         return AdapterActionResult(
             message=f"Opening issue #{number} in the browser instead.",
             warning="Note: 'issue develop' does not create a local branch on GitCode.",

--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -533,6 +533,10 @@ def issue_develop(
     name: str | None,
 ) -> None:
     app = ctx.obj["app"]
+    if base is not None:
+        raise unsupported("ISSUE_DEVELOP_BASE")
+    if name is not None:
+        raise unsupported("ISSUE_DEVELOP_NAME")
     url_owner, url_repo, number = resolve_issue_arg(identifier)
     if url_owner:
         assert url_repo is not None

--- a/tests/unit/adapters/test_issue_adapter.py
+++ b/tests/unit/adapters/test_issue_adapter.py
@@ -168,14 +168,11 @@ class TestIssueAdapter:
 
         service.update.assert_called_once_with("owner", "repo", "42", labels="existing,bug,docs")
 
-    def test_develop_rejects_base_and_name_through_capability_policy(self, adapter):
-        with pytest.raises(Exception) as base_exc:
-            adapter.develop("owner", "repo", "42", base="main", name=None)
-        assert "--base" in str(base_exc.value)
+    def test_develop_returns_browser_fallback_message(self, adapter):
+        result = adapter.develop("owner", "repo", "42", base="main", name="feature")
 
-        with pytest.raises(Exception) as name_exc:
-            adapter.develop("owner", "repo", "42", base=None, name="feature")
-        assert "--name" in str(name_exc.value)
+        assert result.message == "Opening issue #42 in the browser instead."
+        assert result.warning == "Note: 'issue develop' does not create a local branch on GitCode."
 
     def test_status_returns_approximation_message(self, adapter, service):
         service.list.return_value = [{"number": "1", "state": "open", "title": "Test"}]

--- a/tests/unit/commands/test_issue_adapter_boundary.py
+++ b/tests/unit/commands/test_issue_adapter_boundary.py
@@ -118,3 +118,35 @@ class TestIssueCommandAdapterBoundary:
             comment="done",
             reason="completed",
         )
+
+    def test_issue_develop_rejects_unsupported_base_before_adapter(
+        self, runner: CliRunner, mock_repo: None, mock_app_client: MagicMock
+    ) -> None:
+        issue_service_ctor = MagicMock()
+        issue_adapter_ctor = MagicMock()
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("gitcode_cli.commands.issue.IssueService", issue_service_ctor)
+            mp.setattr("gitcode_cli.commands.issue.IssueAdapter", issue_adapter_ctor)
+            result = runner.invoke(main, ["issue", "develop", "42", "--base", "main"])
+
+        assert result.exit_code != 0
+        assert "--base" in result.output
+        issue_service_ctor.assert_not_called()
+        issue_adapter_ctor.assert_not_called()
+
+    def test_issue_develop_rejects_unsupported_name_before_adapter(
+        self, runner: CliRunner, mock_repo: None, mock_app_client: MagicMock
+    ) -> None:
+        issue_service_ctor = MagicMock()
+        issue_adapter_ctor = MagicMock()
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("gitcode_cli.commands.issue.IssueService", issue_service_ctor)
+            mp.setattr("gitcode_cli.commands.issue.IssueAdapter", issue_adapter_ctor)
+            result = runner.invoke(main, ["issue", "develop", "42", "--name", "feature"])
+
+        assert result.exit_code != 0
+        assert "--name" in result.output
+        issue_service_ctor.assert_not_called()
+        issue_adapter_ctor.assert_not_called()


### PR DESCRIPTION
## Description

Move `gc issue develop` unsupported flag checks for `--base` and `--name` into the command layer, and leave `IssueAdapter.develop()` responsible only for GitCode fallback behavior. Update the boundary tests to match the new responsibility split.

## Related Issue

Closes #92

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [ ] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide