### PR TITLE
Fix jq CLI fallback pretty-printed multi-output parsing

### DIFF
--- a/src/gitcode_cli/formatters.py
+++ b/src/gitcode_cli/formatters.py
@@ -126,7 +126,7 @@ def apply_jq(data, query: str):
     jq_bin = shutil.which("jq")
     if jq_bin:
         proc = subprocess.run(
-            [jq_bin, query],
+            [jq_bin, "-c", query],
             input=json.dumps(data),
             capture_output=True,
             text=True,

--- a/tests/unit/test_formatters.py
+++ b/tests/unit/test_formatters.py
@@ -228,6 +228,13 @@ class TestApplyJq:
         mocker.patch("gitcode_cli.formatters.shutil.which", return_value="/usr/bin/jq")
         result = apply_jq({"id": 1}, ".id")
         assert result == [{"id": 1}]
+        mock_run.assert_called_once_with(
+            ["/usr/bin/jq", "-c", ".id"],
+            input='{"id": 1}',
+            capture_output=True,
+            text=True,
+            check=True,
+        )
 
     def test_jq_cli_multiple_json_lines(self, mocker):
         mocker.patch.dict("sys.modules", {"jq": None})
@@ -236,6 +243,7 @@ class TestApplyJq:
         mocker.patch("gitcode_cli.formatters.shutil.which", return_value="/usr/bin/jq")
         result = apply_jq([{"id": 1}, {"id": 2}], ".[]")
         assert result == [{"id": 1}, {"id": 2}]
+        assert mock_run.call_args.args[0] == ["/usr/bin/jq", "-c", ".[]"]
 
     def test_jq_cli_empty_output_returns_empty_list(self, mocker):
         mocker.patch.dict("sys.modules", {"jq": None})


### PR DESCRIPTION
## Description

Follow up on #95 to fully fix issue #94 in the external `jq` fallback path.

PR #95 fixed the case where `jq` emits multiple compact JSON values, but it did not account for the default `jq` CLI behavior of pretty-printing each result across multiple lines. In that real output mode, the previous line-based parser still failed.

This PR fixes the remaining bug by forcing compact output from the external `jq` process with `jq -c`, so each emitted JSON value is a complete single-line document before parsing.

- add `-c` to the external `jq` fallback invocation
- keep the existing multi-item parsing logic from #95
- update tests to assert the CLI fallback actually invokes `jq -c`

## Related Issue

Fixes #94
Follow-up to #95

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [ ] Test coverage remains >= 90%

Validation run for this follow-up change:
- `conda run -n gitcode-cli pytest --no-cov tests/unit/test_formatters.py`
- `conda run -n gitcode-cli ruff check src/ tests/`
- `conda run -n gitcode-cli ruff format --check src/ tests/`
- `conda run -n gitcode-cli basedpyright src/`

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [ ] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide