### PR TITLE
docs: split README and docs by language

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,219 +6,62 @@
 [![Python](https://img.shields.io/pypi/pyversions/pygitcode)](https://pypi.org/project/pygitcode/)
 [![License](https://img.shields.io/pypi/l/pygitcode)](https://github.com/codeasier/gitcode-cli/blob/main/LICENSE)
 
+English | [中文](README.zh-CN.md)
+
 ## Installation
 
 ```bash
 pip install pygitcode
 ```
 
-This exposes the `gc` (or `gitcode`) command in your shell.
-
-## Windows PowerShell Users
-
-On Windows PowerShell, `gc` is a built-in alias for the `Get-Content` cmdlet, which shadows the GitCode CLI. Use `gitcode` instead:
-
-```powershell
-gitcode auth login
-gitcode issue list
-gitcode pr list
-```
-
-Alternatively, you can remove or override the alias in your PowerShell profile:
-
-```powershell
-# Remove for the current session
-Remove-Item Alias:gc -Force
-
-# Or persist the override in your profile
-Set-Alias -Name gc -Value 'C:\Users\<user>\AppData\Roaming\Python\Python313\Scripts\gc.exe'
-```
+This exposes both `gc` and `gitcode` commands in your shell.
 
 ## Quick Start
 
-### Authentication
+If you already know GitHub CLI (`gh`), you can start with the same familiar flows:
 
 ```bash
-# Login with your GitCode personal access token
 gc auth login
-
-# Check auth status
-gc auth status
-
-# Print the current auth token
-gc auth token
-
-# Logout
-gc auth logout
-
-# Or set environment variable
-export GC_TOKEN=your_token_here
-```
-
-### Issues
-
-```bash
-# List issues (with filtering options)
 gc issue list
-gc issue list --state closed --author @me
-gc issue list --label bug --label "help wanted"
-gc issue list --web    # Open in browser
-
-# View an issue (with comments)
 gc issue view 42
-gc issue view 42 --comments
-gc issue view 42 --web
-
-# Create an issue
-gc issue create -t "Bug report" -b "Something is broken"
-gc issue create --label bug --label "help wanted"   # Multiple labels
-gc issue create --web    # Create in browser
-
-# Edit an issue (title, labels, assignee, milestone)
-gc issue edit 42 -t "Updated title"
-gc issue edit 42 --add-label bug --add-label docs
-gc issue edit 42 --add-assignee @me
-gc issue edit 42 --milestone v1.0 --remove-milestone
-
-# Comment on an issue
-gc issue comment 42 -b "Thanks for the report!"
-gc issue comment 42 --editor    # Use system editor
-
-gc issue delete 42              # Delete an issue (prompts by default)
-gc issue delete 42 --yes        # Skip confirmation
-
-# Close / reopen
-gc issue close 42
-gc issue close 42 -c "Fixed in #50" --reason completed
-```
-
-### Pull Requests
-
-```bash
-# List PRs (with filtering options)
 gc pr list
-gc pr list --state merged --author @me
-gc pr list --base main --draft
-gc pr list --web    # Open in browser
-
-# View a PR (identifier optional - infers from current branch)
-gc pr view           # View PR for current branch
-gc pr view 42        # By number
-gc pr view 42 --comments   # Include comments
-gc pr view https://gitcode.com/owner/repo/pulls/42
-gc pr view feature-branch
-
-# Create a PR (auto-detects current branch and default base)
-gc pr create -t "Add new feature"
-
-# Create with auto-fill from commits
-gc pr create --fill              # Use latest commit
-gc pr create --fill-first        # Use first commit
-gc pr create --fill-verbose      # Use all commits for body
-
-# Create with editor
-gc pr create --editor
-
-# Preview without creating
-gc pr create --dry-run
-
-# Create in browser
-gc pr create --web
-
-# Close / merge / reopen (identifier optional)
-gc pr close          # Close PR for current branch
-gc pr close 42 -c "Closing as stale"
-gc pr close --delete-branch    # Delete remote branch too
-
-gc pr merge          # Merge PR for current branch
-gc pr merge 42 -s    # Squash merge
-gc pr merge --rebase
-gc pr merge --delete-branch    # Delete remote branch after merge
-
-# Edit a PR (add/remove labels, assignees, reviewers, milestones)
-gc pr edit 42 -t "New title"
-gc pr edit --add-label bug --remove-label "needs review"
-gc pr edit --add-reviewer @me --remove-reviewer otheruser
-gc pr edit --milestone v1.0 --remove-milestone
-
-# Mark as ready or convert to draft
-gc pr ready          # Mark current branch's PR as ready
-gc pr ready --undo   # Convert back to draft
-
-# Comment / review / diff (identifier optional)
-gc pr comment -b "LGTM"
-gc pr comment --path src/file.py --position 5 -b "Suggestion"
-gc pr comment --body-file comment.txt
-gc pr comment --editor
-
-gc pr review --approve
-gc pr review --comment -b "Looks good but needs tests"
-gc pr review --request-changes -b "Missing documentation"
-
-gc pr diff           # View diff for current branch's PR
-gc pr diff 42
-
-# Checkout a PR (identifier optional)
-gc pr checkout        # Checkout PR for current branch? (prompts if ambiguous)
-gc pr checkout 42
-gc pr checkout -b local-branch-name
+gc pr create --fill
+gc pr merge 42 --squash
 ```
 
-### Global Options
-
-```bash
-# Use a different repo without cd-ing into it
-gc issue list -R owner/repo
-gc pr list -R owner/repo
-
-# Output as JSON with field selection
-gc issue list --json number,title,state,author
-gc pr list --json number,title,state,head,base
-
-# Filter with jq
-gc issue list -q '.[] | select(.state == "open")'
-gc pr list -q '.[] | select(.draft == true)'
-
-# Format with Go-style templates
-gc issue list -t '{{.number}} {{.title}} ({{.state}})'
-gc pr view -t 'PR #{{.number}}: {{.title}}\n{{.body}}'
-
-# Open in browser
-gc issue view 42 -w
-gc pr view -w
-```
+Use `gitcode` instead of `gc` on Windows PowerShell because `gc` is a built-in alias for `Get-Content`.
 
 ## Documentation
 
-- [Documentation index](docs/index.md)
-- [Development guide](docs/development.md)
+- [Documentation index](docs/en/index.md)
+- [Development guide](docs/en/development.md)
+- [Compatibility notes](docs/en/gh-compatibility.md)
 
-## Alignment with `gh` CLI
+## Repository Selection
 
-`pygitcode` aims to be as familiar as possible to `gh` users:
+Commands operate on the current Git repository by default. You can also select a repository explicitly:
 
-| Feature | `gh` | `gc` |
-|---------|------|------|
-| PR identifier optional (current branch inference) | ✅ | ✅ |
-| `--fill` / `--fill-first` / `--fill-verbose` | ✅ | ✅ |
-| `--editor` | ✅ | ✅ |
-| `--dry-run` | ✅ | ✅ |
-| `--web` (create/view in browser) | ✅ | ✅ |
-| `--remove-*` flags for edit commands | ✅ | ✅ |
-| `pr ready --undo` (convert to draft) | ✅ | ✅ |
-| `pr review --request-changes` | ✅ | ✅ (fallback) |
-| `--json fields` | ✅ | ✅ |
-| `-q jq` filtering | ✅ | ✅ |
-| `-t template` formatting | ✅ | ✅ |
-| Command aliases (`ls` → `list`, `new` → `create`) | ✅ | ✅ |
-| Multi-value options (`--label bug --label feature`) | ✅ | ✅ |
+```bash
+gc issue list -R owner/repo
+gc pr list -R owner/repo
+```
 
-### Known Limitations (GitCode API differences)
+## Authentication
 
-- **PR comment model**: GitCode uses `path + position`, not GitHub's `line/side/commit`
-- **PR review**: GitCode review API differs from GitHub; `--request-changes` falls back to PR comments
-- **Issue deletion**: `gc issue delete` relies on GitCode issue deletion support that is not currently documented in the public API; behavior may change if GitCode adjusts this endpoint
-- **Issue create/update API**: GitCode puts `repo` in request body, not URL path
+`gc` resolves tokens in this order:
+
+1. `--token` option
+2. `GC_TOKEN` environment variable
+3. `~/.config/gc/config.json`, written by `gc auth login`
+
+Useful commands:
+
+```bash
+gc auth login
+gc auth status
+gc auth token
+gc auth logout
+```
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,68 @@
+# pygitcode
+
+> `pygitcode` 是面向 [GitCode](https://gitcode.com/)（`api.gitcode.com`）的命令行工具，命令体验尽量对齐 GitHub CLI（`gh`）。
+
+[![PyPI](https://img.shields.io/pypi/v/pygitcode)](https://pypi.org/project/pygitcode/)
+[![Python](https://img.shields.io/pypi/pyversions/pygitcode)](https://pypi.org/project/pygitcode/)
+[![License](https://img.shields.io/pypi/l/pygitcode)](https://github.com/codeasier/gitcode-cli/blob/main/LICENSE)
+
+[English](README.md) | 中文
+
+## 安装
+
+```bash
+pip install pygitcode
+```
+
+安装后会提供 `gc` 和 `gitcode` 两个命令。
+
+## 快速开始
+
+如果你熟悉 GitHub CLI（`gh`），可以直接从这些常见流程开始：
+
+```bash
+gc auth login
+gc issue list
+gc issue view 42
+gc pr list
+gc pr create --fill
+gc pr merge 42 --squash
+```
+
+在 Windows PowerShell 中请优先使用 `gitcode`，因为 `gc` 是内置 `Get-Content` 别名。
+
+## 文档
+
+- [文档索引](docs/zh-CN/index.md)
+- [开发指南](docs/zh-CN/development.md)
+- [兼容性说明](docs/zh-CN/gh-compatibility.md)
+
+## 仓库选择
+
+默认情况下，命令会使用当前 Git 仓库。也可以通过 `-R owner/repo` 显式指定仓库：
+
+```bash
+gc issue list -R owner/repo
+gc pr list -R owner/repo
+```
+
+## 认证
+
+`gc` 按以下优先级读取 token：
+
+1. `--token` 参数
+2. `GC_TOKEN` 环境变量
+3. `gc auth login` 写入的 `~/.config/gc/config.json`
+
+常用命令：
+
+```bash
+gc auth login
+gc auth status
+gc auth token
+gc auth logout
+```
+
+## License
+
+MIT

--- a/docs/en/development.md
+++ b/docs/en/development.md
@@ -1,0 +1,38 @@
+# Development
+
+[中文](../zh-CN/development.md) | English
+
+## Setup
+
+```bash
+git clone https://github.com/codeasier/gitcode-cli.git
+cd gitcode-cli
+pip install -e ".[dev]"
+```
+
+## Run tests
+
+Run the full suite:
+
+```bash
+conda run -n gitcode-cli python -m pytest tests
+```
+
+Run one layer:
+
+```bash
+conda run -n gitcode-cli python -m pytest tests/unit/commands
+conda run -n gitcode-cli python -m pytest tests/unit/adapters
+conda run -n gitcode-cli python -m pytest tests/unit/services
+conda run -n gitcode-cli python -m pytest tests/contracts
+```
+
+For test layout and intent, see [tests/README.md](../../tests/README.md).
+
+## Static checks
+
+```bash
+python -m ruff check src/ tests/
+python -m ruff format src/ tests/
+python -m basedpyright src/
+```

--- a/docs/en/gh-compatibility.md
+++ b/docs/en/gh-compatibility.md
@@ -1,0 +1,30 @@
+# Compatibility notes
+
+[中文](../zh-CN/gh-compatibility.md) | English
+
+`pygitcode` aims to feel familiar to `gh` users while adapting to GitCode API behavior.
+
+## Aligned capabilities
+
+| Capability | Status in `gc` |
+| --- | --- |
+| Issue and PR list/view/create/comment/edit/close flows | Supported |
+| PR identifier inference from the current branch | Supported |
+| `pr create --fill`, `--fill-first`, `--fill-verbose` | Supported |
+| `--editor`, `--dry-run`, and `--web` where applicable | Supported |
+| `--json`, `-q`, and `-t` output shaping | Supported |
+| Command aliases such as `ls` → `list`, `new` → `create` | Supported |
+| Multi-value options such as repeated `--label` | Supported |
+| Edit helpers such as `--add-label` / `--remove-label` | Supported |
+
+## GitCode differences and limitations
+
+| Area | Difference in `gc` |
+| --- | --- |
+| Authentication | GitCode uses an `access_token` query parameter rather than GitHub's API authentication model. |
+| Issue create/update API | GitCode issue create/update sends `repo` in the request body instead of encoding it only in the URL path. |
+| PR inline comments | GitCode uses `path + position`; GitHub-style `line`, `side`, and `commit` review coordinates are not equivalent. |
+| PR review changes | `gc pr review --request-changes` is approximated with a PR comment because GitCode's review API differs from GitHub's. |
+| Issue deletion | `gc issue delete` relies on GitCode issue deletion behavior that is not documented in the public API and may change. |
+| Draft/readiness operations | `gc pr ready --undo` toggles draft state through the GitCode PR update capability; behavior may differ from GitHub draft PR semantics. |
+| Browser flows | `--web` opens the corresponding GitCode page; browser-created content depends on GitCode's web UI. |

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,0 +1,10 @@
+# Documentation
+
+[中文](../zh-CN/index.md) | English
+
+## Getting started
+
+- [Development guide](development.md) — setup, tests, and static checks
+- [Test architecture](../../tests/README.md) — test layers and intent
+- [Roadmap](../../ROADMAP.md) — planned features and remaining gaps
+- [Compatibility notes](gh-compatibility.md) — aligned `gh` behaviors and GitCode differences

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,0 @@
-# Documentation
-
-- [Development guide](development.md) — setup, tests, and static checks
-- [Test architecture](../tests/README.md) — test layers and intent
-- [Roadmap](../ROADMAP.md) — planned features and remaining gaps

--- a/docs/zh-CN/development.md
+++ b/docs/zh-CN/development.md
@@ -1,6 +1,8 @@
-# Development
+# 开发指南
 
-## Setup
+中文 | [English](../en/development.md)
+
+## 环境准备
 
 ```bash
 git clone https://github.com/codeasier/gitcode-cli.git
@@ -8,15 +10,15 @@ cd gitcode-cli
 pip install -e ".[dev]"
 ```
 
-## Run tests
+## 运行测试
 
-Run the full suite:
+完整执行：
 
 ```bash
 conda run -n gitcode-cli python -m pytest tests
 ```
 
-Run one layer:
+按层执行：
 
 ```bash
 conda run -n gitcode-cli python -m pytest tests/unit/commands
@@ -25,9 +27,9 @@ conda run -n gitcode-cli python -m pytest tests/unit/services
 conda run -n gitcode-cli python -m pytest tests/contracts
 ```
 
-For test layout and intent, see [tests/README.md](../tests/README.md).
+测试布局与设计意图见 [tests/README.md](../../tests/README.md)。
 
-## Static checks
+## 静态检查
 
 ```bash
 python -m ruff check src/ tests/

--- a/docs/zh-CN/gh-compatibility.md
+++ b/docs/zh-CN/gh-compatibility.md
@@ -1,0 +1,30 @@
+# 兼容性说明
+
+中文 | [English](../en/gh-compatibility.md)
+
+`pygitcode` 目标是尽量让 `gh` 用户以熟悉的方式使用 GitCode CLI，同时适配 GitCode API 的实际行为。
+
+## 已对齐能力
+
+| 能力 | `gc` 支持情况 |
+| --- | --- |
+| Issue 和 PR 的 list/view/create/comment/edit/close 流程 | 支持 |
+| 根据当前分支推断 PR 编号 | 支持 |
+| `pr create --fill`、`--fill-first`、`--fill-verbose` | 支持 |
+| 适用命令中的 `--editor`、`--dry-run`、`--web` | 支持 |
+| `--json`、`-q`、`-t` 输出处理 | 支持 |
+| `ls` → `list`、`new` → `create` 等命令别名 | 支持 |
+| 重复传入 `--label` 等多值参数 | 支持 |
+| `--add-label` / `--remove-label` 等编辑辅助参数 | 支持 |
+
+## GitCode 差异与限制
+
+| 范围 | `gc` 中的差异 |
+| --- | --- |
+| 认证方式 | GitCode 使用 `access_token` 查询参数，不同于 GitHub API 的认证模型。 |
+| Issue 创建/更新 API | GitCode 创建/更新 issue 时会在请求体中传入 `repo`，而不是只依赖 URL 路径。 |
+| PR 行内评论 | GitCode 使用 `path + position` 模型；GitHub 的 `line`、`side`、`commit` 坐标不能直接等价映射。 |
+| PR review request changes | `gc pr review --request-changes` 会近似为 PR 评论，因为 GitCode review API 与 GitHub 不同。 |
+| Issue 删除 | `gc issue delete` 依赖 GitCode issue 删除行为，该接口目前未在公开 API 中明确记录，后续可能变化。 |
+| Draft/ready 操作 | `gc pr ready --undo` 通过 GitCode 的 PR 更新能力切换 draft 状态，但语义可能不同于 GitHub draft PR。 |
+| 浏览器流程 | `--web` 会打开对应 GitCode 页面；页面内创建或编辑能力取决于 GitCode Web UI。 |

--- a/docs/zh-CN/index.md
+++ b/docs/zh-CN/index.md
@@ -1,0 +1,10 @@
+# 文档
+
+中文 | [English](../en/index.md)
+
+## 快速入口
+
+- [开发指南](development.md) — 环境准备、测试与静态检查
+- [测试架构](../../tests/README.md) — 测试分层与设计意图
+- [路线图](../../ROADMAP.md) — 规划中的能力与兼容性差距
+- [兼容性说明](gh-compatibility.md) — 与 `gh` 对齐的能力及 GitCode 差异


### PR DESCRIPTION
## Description

- split the root README into focused English and Chinese entry points
- move detailed compatibility and development content into `docs/en/` and `docs/zh-CN/`
- remove legacy top-level docs pages after updating repository links to the new language-specific paths

## Related Issue

- N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [x] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [ ] Lint passes (`python -m ruff check src/ tests/`)
- [ ] Format passes (`python -m ruff format --check src/ tests/`)
- [ ] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [ ] I have added tests that prove my fix/feature works
- [x] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide