### PR TITLE
Fix issue status compatibility gaps

### DIFF
--- a/src/gitcode_cli/adapters/capabilities.py
+++ b/src/gitcode_cli/adapters/capabilities.py
@@ -12,7 +12,8 @@ CAPABILITY_MESSAGES = {
     "ISSUE_DEVELOP_NAME": "--base and --name are not supported by 'gc issue develop'",
     "ISSUE_LIST_APP": "GitCode issue API does not support --app filtering.",
     "ISSUE_STATUS_GH_SEMANTICS": (
-        "GitCode-limited approximation of gh issue status: mentioned issues use repository mention filtering."
+        "GitCode-limited approximation of gh issue status: assigned and opened issues use user-level "
+        "GitCode results; mentioned issues use repository mention filtering."
     ),
     "PR_MERGE_AUTHOR_EMAIL": "GitCode merge API does not support --author-email.",
     "PR_MERGE_AUTO": "GitCode merge API does not support --auto.",

--- a/src/gitcode_cli/adapters/capabilities.py
+++ b/src/gitcode_cli/adapters/capabilities.py
@@ -11,7 +11,9 @@ CAPABILITY_MESSAGES = {
     "ISSUE_DEVELOP_BASE": "--base and --name are not supported by 'gc issue develop'",
     "ISSUE_DEVELOP_NAME": "--base and --name are not supported by 'gc issue develop'",
     "ISSUE_LIST_APP": "GitCode issue API does not support --app filtering.",
-    "ISSUE_STATUS_GH_SEMANTICS": "GitCode-limited approximation of gh issue status",
+    "ISSUE_STATUS_GH_SEMANTICS": (
+        "GitCode-limited approximation of gh issue status: mentioned issues use repository mention filtering."
+    ),
     "PR_MERGE_AUTHOR_EMAIL": "GitCode merge API does not support --author-email.",
     "PR_MERGE_AUTO": "GitCode merge API does not support --auto.",
     "PR_REVIEW_REQUEST_CHANGES": (

--- a/src/gitcode_cli/adapters/issues.py
+++ b/src/gitcode_cli/adapters/issues.py
@@ -229,9 +229,16 @@ class IssueAdapter:
         return self.service.update(owner, repo, number, **data)
 
     def status(self, owner: str, repo: str) -> AdapterActionResult:
-        items = self.service.list(owner, repo, state="open")
+        if self.user_service is None:
+            raise click.ClickException("failed to resolve current user: current user lookup is unavailable")
+        current_login = _extract_login(self.user_service.current())
+        if not current_login:
+            raise click.ClickException("failed to resolve current user: current user has no login")
+        assigned = self.service.list_user_issues(filter="assigned", state="open") or []
+        created = self.service.list_user_issues(filter="created", state="open") or []
+        mentioned = self.service.list(owner, repo, state="open", mention=current_login) or []
         return AdapterActionResult(
-            items=items,
+            item={"assigned": assigned, "mentioned": mentioned, "createdBy": created},
             message=capability_message("ISSUE_STATUS_GH_SEMANTICS"),
             approximated=True,
         )

--- a/src/gitcode_cli/client.py
+++ b/src/gitcode_cli/client.py
@@ -46,14 +46,14 @@ class GitCodeClient:
         if response.status_code == 401:
             try:
                 data = response.json()
-                original = data.get("message") or str(data)
+                original = data.get("error_message") or data.get("message") or str(data)
             except Exception:
                 original = response.text
             raise APIError(f"Authentication failed: {original}. Run 'gc auth login' to authenticate.", 401)
         if response.status_code >= 400:
             try:
                 data = response.json()
-                message = data.get("message") or str(data)
+                message = data.get("error_message") or data.get("message") or str(data)
             except Exception:
                 message = response.text
             raise APIError(message or "GitCode API request failed", response.status_code)

--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -26,6 +26,43 @@ def _echo_issue_summary(items: list[dict]) -> None:
         safe_echo(output)
 
 
+def _issue_status_labels(item: dict) -> str:
+    labels = item.get("labels") or []
+    if isinstance(labels, str):
+        return labels
+    names = []
+    for label in labels:
+        if isinstance(label, dict):
+            name = label.get("name") or label.get("title")
+            if name:
+                names.append(str(name))
+        elif label:
+            names.append(str(label))
+    return ", ".join(names)
+
+
+def _echo_issue_status(data: dict[str, list[dict]]) -> None:
+    sections = [
+        ("Issues assigned to you", data.get("assigned") or []),
+        ("Issues mentioning you", data.get("mentioned") or []),
+        ("Issues opened by you", data.get("createdBy") or []),
+    ]
+    for title, items in sections:
+        safe_echo(title)
+        if not items:
+            safe_echo("  No issues found")
+            safe_echo("")
+            continue
+        for item in items:
+            labels = _issue_status_labels(item)
+            created_at = item.get("created_at") or item.get("createdAt") or ""
+            safe_echo(
+                f"  #{safe_number(item, '?')}  {str(item.get('state') or '').upper()}  "
+                f"{item.get('title') or ''}  {labels}  {created_at}".rstrip()
+            )
+        safe_echo("")
+
+
 def _pending_gh_compat(name: str) -> None:
     raise click.ClickException(f"gh-compatible command/flag '{name}' is recognized but not implemented yet.")
 
@@ -506,17 +543,32 @@ def issue_delete(ctx: click.Context, repo_name: str | None, identifier: str, yes
 
 @issue_group.command("status")
 @click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
+@click.option("--json", "json_fields", help="Output JSON. Optionally specify comma-separated fields.")
+@click.option("-q", "--jq", "jq_query", help="Filter JSON output using a jq expression.")
+@click.option("-t", "--template", help="Format output using a Go template string.")
 @click.pass_context
-def issue_status(ctx: click.Context, repo_name: str | None) -> None:
+def issue_status(
+    ctx: click.Context,
+    repo_name: str | None,
+    json_fields: str | None,
+    jq_query: str | None,
+    template: str | None,
+) -> None:
     app = ctx.obj["app"]
     owner, repo = resolve_repo(repo_name or app.repo)
     service = IssueService(app.client())
-    adapter = IssueAdapter(service)
+    adapter = IssueAdapter(service, UserService(app.client()))
     result = adapter.status(owner, repo)
-    safe_echo(result.message)
-    safe_echo(f"Repository open issues for {owner}/{repo}:")
-    for item in result.items or []:
-        safe_echo(f"  #{safe_number(item, '?')}\t{item['state']}\t{item['title']}")
+    data = result.item or {"assigned": [], "mentioned": [], "createdBy": []}
+    if json_fields or jq_query or template:
+        output_result(data, json_fields, jq_query, template, default_formatter=_echo_issue_status)
+        return
+    safe_echo(f"Relevant issues in {owner}/{repo}")
+    safe_echo("")
+    if result.message:
+        safe_echo(result.message)
+        safe_echo("")
+    _echo_issue_status(data)
 
 
 @issue_group.command("develop")

--- a/src/gitcode_cli/services/issues.py
+++ b/src/gitcode_cli/services/issues.py
@@ -12,6 +12,9 @@ class IssueService:
     def list(self, owner: str, repo: str, **params: Any) -> Any | None:
         return self.client.get(f"/repos/{owner}/{repo}/issues", params=params)
 
+    def list_user_issues(self, **params: Any) -> Any | None:
+        return self.client.get("/user/issues", params=params)
+
     def get(self, owner: str, repo: str, number: str) -> Any | None:
         return self.client.get(f"/repos/{owner}/{repo}/issues/{number}")
 

--- a/tests/unit/adapters/test_issue_adapter.py
+++ b/tests/unit/adapters/test_issue_adapter.py
@@ -246,7 +246,8 @@ class TestIssueAdapter:
 
         assert result.approximated is True
         assert result.message == (
-            "GitCode-limited approximation of gh issue status: mentioned issues use repository mention filtering."
+            "GitCode-limited approximation of gh issue status: assigned and opened issues use user-level "
+            "GitCode results; mentioned issues use repository mention filtering."
         )
         assert result.item == {
             "assigned": [{"number": "1", "state": "open", "title": "Assigned"}],

--- a/tests/unit/adapters/test_issue_adapter.py
+++ b/tests/unit/adapters/test_issue_adapter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 
@@ -234,11 +234,27 @@ class TestIssueAdapter:
         assert result.message == "Opening issue #42 in the browser instead."
         assert result.warning == "Note: 'issue develop' does not create a local branch on GitCode."
 
-    def test_status_returns_approximation_message(self, adapter, service):
-        service.list.return_value = [{"number": "1", "state": "open", "title": "Test"}]
+    def test_status_returns_grouped_user_context(self, adapter, service, user_service):
+        user_service.current.return_value = {"login": "alice"}
+        service.list_user_issues.side_effect = [
+            [{"number": "1", "state": "open", "title": "Assigned"}],
+            [{"number": "2", "state": "open", "title": "Created"}],
+        ]
+        service.list.return_value = [{"number": "3", "state": "open", "title": "Mentioned"}]
 
         result = adapter.status("owner", "repo")
 
         assert result.approximated is True
-        assert result.message == "GitCode-limited approximation of gh issue status"
-        assert result.items == [{"number": "1", "state": "open", "title": "Test"}]
+        assert result.message == (
+            "GitCode-limited approximation of gh issue status: mentioned issues use repository mention filtering."
+        )
+        assert result.item == {
+            "assigned": [{"number": "1", "state": "open", "title": "Assigned"}],
+            "mentioned": [{"number": "3", "state": "open", "title": "Mentioned"}],
+            "createdBy": [{"number": "2", "state": "open", "title": "Created"}],
+        }
+        assert service.list_user_issues.call_args_list == [
+            call(filter="assigned", state="open"),
+            call(filter="created", state="open"),
+        ]
+        service.list.assert_called_once_with("owner", "repo", state="open", mention="alice")

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -792,27 +792,42 @@ class TestIssueDevelop:
 
 class TestIssueStatus:
     def test_default(self, runner, mock_client, mock_repo):
-        mock_client.get.return_value = [{"number": "1", "state": "open", "title": "T"}]
-        result = runner.invoke(main, ["issue", "status"])
-        assert result.exit_code == 0
-        assert "GitCode-limited approximation" in result.output
-        assert "Repository open issues" in result.output
-        mock_client.get.assert_called_once()
-
-    def test_lists_repository_open_issues_with_limited_wording(self, runner, mock_client, mock_repo):
-        mock_client.get.return_value = [
-            {
-                "number": "1",
-                "state": "open",
-                "title": "Mine",
-                "author": {"login": "alice"},
-                "assignee": {"login": "alice"},
-            },
-            {"number": "2", "state": "open", "title": "Other", "author": {"login": "bob"}},
+        mock_client.get.side_effect = [
+            {"login": "alice"},
+            [
+                {
+                    "number": "1",
+                    "state": "open",
+                    "title": "Assigned",
+                    "labels": [{"name": "bug"}],
+                    "created_at": "2026-05-10T14:40:59Z",
+                }
+            ],
+            [],
+            [],
         ]
         result = runner.invoke(main, ["issue", "status"])
         assert result.exit_code == 0
+        assert "Relevant issues in owner/repo" in result.output
         assert "GitCode-limited approximation" in result.output
-        assert "Repository open issues" in result.output
-        assert "#1" in result.output
-        assert "#2" in result.output
+        assert "Issues assigned to you" in result.output
+        assert "#1  OPEN  Assigned  bug  2026-05-10T14:40:59Z" in result.output
+        assert mock_client.get.call_args_list == [
+            call("/user"),
+            call("/user/issues", params={"filter": "assigned", "state": "open"}),
+            call("/user/issues", params={"filter": "created", "state": "open"}),
+            call("/repos/owner/repo/issues", params={"state": "open", "mention": "alice"}),
+        ]
+
+    def test_json_outputs_grouped_status(self, runner, mock_client, mock_repo):
+        mock_client.get.side_effect = [
+            {"login": "alice"},
+            [{"number": "1", "state": "open", "title": "Assigned"}],
+            [{"number": "2", "state": "open", "title": "Created"}],
+            [{"number": "3", "state": "open", "title": "Mentioned"}],
+        ]
+        result = runner.invoke(main, ["issue", "status", "--json", "assigned,createdBy"])
+        assert result.exit_code == 0
+        assert '"assigned"' in result.output
+        assert '"createdBy"' in result.output
+        assert '"mentioned"' not in result.output

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -831,3 +831,32 @@ class TestIssueStatus:
         assert '"assigned"' in result.output
         assert '"createdBy"' in result.output
         assert '"mentioned"' not in result.output
+
+    def test_jq_outputs_grouped_status(self, runner, mock_client, mock_repo):
+        mock_client.get.side_effect = [
+            {"login": "alice"},
+            [{"number": "1", "state": "open", "title": "Assigned"}],
+            [],
+            [],
+        ]
+        result = runner.invoke(main, ["issue", "status", "--jq", ".assigned[].title"])
+        assert result.exit_code == 0
+        assert result.output == '[\n  "Assigned"\n]\n'
+
+    def test_template_outputs_grouped_status(self, runner, mock_client, mock_repo):
+        mock_client.get.side_effect = [
+            {"login": "alice"},
+            [{"number": "1", "state": "open", "title": "Assigned"}],
+            [],
+            [],
+        ]
+        result = runner.invoke(main, ["issue", "status", "--template", "{{.assigned}}"])
+        assert result.exit_code == 0
+        assert "Assigned" in result.output
+        assert "number" in result.output
+
+    def test_status_fails_when_current_user_has_no_login(self, runner, mock_client, mock_repo):
+        mock_client.get.return_value = {}
+        result = runner.invoke(main, ["issue", "status"])
+        assert result.exit_code != 0
+        assert "current user has no login" in result.output

--- a/tests/unit/services/test_issues.py
+++ b/tests/unit/services/test_issues.py
@@ -27,6 +27,13 @@ class TestIssueService:
         mock_client.get.assert_called_once_with("/repos/owner/repo/issues", params={"state": "open", "per_page": 10})
         assert result == [{"number": "1"}]
 
+    def test_list_user_issues(self, service, mock_client):
+        mock_client.get.return_value = [{"number": "1"}]
+        result = service.list_user_issues(filter="assigned", state="open")
+
+        mock_client.get.assert_called_once_with("/user/issues", params={"filter": "assigned", "state": "open"})
+        assert result == [{"number": "1"}]
+
     def test_get(self, service, mock_client):
         mock_client.get.return_value = {"number": "42"}
         result = service.get("owner", "repo", "42")

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -94,6 +94,22 @@ class TestGitCodeClientMethods:
             with pytest.raises(APIError, match="Bad request"):
                 client.get("error")
 
+    def test_api_error_prefers_error_message(self, client: GitCodeClient):
+        with respx.mock:
+            respx.get("https://api.gitcode.com/api/v5/error").mock(
+                return_value=Response(
+                    404,
+                    json={
+                        "error_code": 404,
+                        "error_message": "Project not found:owner/missing",
+                        "trace_id": "hidden",
+                    },
+                )
+            )
+            with pytest.raises(APIError, match="Project not found:owner/missing") as exc_info:
+                client.get("error")
+            assert "trace_id" not in str(exc_info.value)
+
     def test_api_error_with_non_json_body(self, client: GitCodeClient):
         with respx.mock:
             respx.get("https://api.gitcode.com/api/v5/error").mock(


### PR DESCRIPTION
## Description

Fixes `gc issue status` compatibility gaps by grouping results into assigned, mentioned, and created sections, adding `--json`/`--jq`/`--template`, and showing labels plus creation timestamps in the default output. Also formats GitCode API errors with `error_message` instead of exposing raw response dictionaries.

## Related Issue

Fixes #105

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

Verified by pre-commit during commit:

- `ruff`
- `ruff-format`
- `basedpyright`
- `pytest`

Also ran full suite manually:

- `conda run -n gitcode-cli pytest` — 461 passed, coverage 92.71%

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide