### PR TITLE
Fix gc issue create validation

### DIFF
--- a/src/gitcode_cli/adapters/issues.py
+++ b/src/gitcode_cli/adapters/issues.py
@@ -16,6 +16,13 @@ def _normalize_multi_values(values: tuple[str, ...] | None) -> str | None:
     return ",".join(values)
 
 
+def _normalize_labels(labels: tuple[str, ...] | None) -> tuple[str, ...] | None:
+    if not labels:
+        return None
+    normalized = tuple(label.strip() for label in labels if label.strip())
+    return normalized or None
+
+
 def _extract_label_names(issue: dict[str, Any] | None) -> list[str]:
     labels = issue.get("labels") if isinstance(issue, dict) else None
     if not labels:
@@ -58,10 +65,72 @@ def _extract_login(data: dict[str, Any] | None) -> str | None:
     return None
 
 
+def _as_list(items: Any) -> list[Any]:
+    return items if isinstance(items, list) else []
+
+
+def _extract_label_options(items: list[Any]) -> set[str]:
+    names: set[str] = set()
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        if isinstance(name, str) and name.strip():
+            names.add(name.strip())
+    return names
+
+
+def _resolve_milestone_number(items: list[Any], milestone: str | None) -> int | None:
+    if milestone is None:
+        return None
+    value = milestone.strip()
+    if not value:
+        return None
+    if value.isdigit():
+        return int(value)
+    matches: list[int] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        title = item.get("title")
+        number = item.get("number")
+        if title != value:
+            continue
+        if isinstance(number, int):
+            matches.append(number)
+        elif isinstance(number, str) and number.isdigit():
+            matches.append(int(number))
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        raise click.ClickException(f"could not resolve milestone: '{value}' matched multiple milestones")
+    raise click.ClickException(f"could not resolve milestone: '{value}' not found")
+
+
 class IssueAdapter:
     def __init__(self, service: IssueService, user_service: UserService | None = None):
         self.service = service
         self.user_service = user_service
+
+    def _list_all_labels(self, owner: str, repo: str) -> list[Any]:
+        items: list[Any] = []
+        page = 1
+        while True:
+            page_items = _as_list(self.service.list_labels(owner, repo, page=page, per_page=100))
+            items.extend(page_items)
+            if len(page_items) < 100:
+                return items
+            page += 1
+
+    def _list_all_milestones(self, owner: str, repo: str) -> list[Any]:
+        items: list[Any] = []
+        page = 1
+        while True:
+            page_items = _as_list(self.service.list_milestones(owner, repo, state="all", page=page, per_page=100))
+            items.extend(page_items)
+            if len(page_items) < 100:
+                return items
+            page += 1
 
     def list_issues(
         self,
@@ -110,16 +179,28 @@ class IssueAdapter:
         body: str | None,
         assignee: str | None,
         labels: tuple[str, ...] | None,
-        milestone: int | None,
+        milestone: str | None,
     ) -> dict[str, Any] | None:
+        normalized_labels = _normalize_labels(labels)
+        if normalized_labels:
+            available_labels = _extract_label_options(self._list_all_labels(owner, repo))
+            for label in normalized_labels:
+                if label not in available_labels:
+                    raise click.ClickException(f"could not add label: '{label}' not found")
+        milestone_number = None
+        if milestone is not None:
+            milestones = []
+            if not milestone.strip().isdigit():
+                milestones = self._list_all_milestones(owner, repo)
+            milestone_number = _resolve_milestone_number(milestones, milestone)
         return self.service.create(
             owner,
             repo,
             title=title,
             body=body,
             assignee=assignee,
-            labels=_normalize_multi_values(labels),
-            milestone=milestone,
+            labels=_normalize_multi_values(normalized_labels),
+            milestone=milestone_number,
         )
 
     def close_issue(

--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -310,7 +310,7 @@ def issue_view(
 @click.option("-a", "--assignee")
 @click.option("-e", "--editor", is_flag=True)
 @click.option("-l", "--label", "labels", multiple=True)
-@click.option("-m", "--milestone", type=int)
+@click.option("-m", "--milestone")
 @click.option("-F", "--body-file")
 @click.option("-w", "--web", is_flag=True, help="Open the issue in the web browser.")
 @click.option("--json", "json_fields", help="Output JSON. Optionally specify comma-separated fields.")
@@ -325,7 +325,7 @@ def issue_create(
     assignee: str | None,
     editor: bool,
     labels: tuple[str, ...] | None,
-    milestone: int | None,
+    milestone: str | None,
     body_file: str | None,
     web: bool,
     json_fields: str | None,
@@ -349,6 +349,8 @@ def issue_create(
     )
     if editor and body is None:
         raise click.ClickException("Editor was closed without saving an issue body.")
+    if body is None:
+        raise click.UsageError("--title and --body are required when not running interactively")
     service = IssueService(app.client())
     adapter = IssueAdapter(service)
     item = adapter.create_issue(

--- a/src/gitcode_cli/services/issues.py
+++ b/src/gitcode_cli/services/issues.py
@@ -15,6 +15,12 @@ class IssueService:
     def list_user_issues(self, **params: Any) -> Any | None:
         return self.client.get("/user/issues", params=params)
 
+    def list_labels(self, owner: str, repo: str, **params: Any) -> Any | None:
+        return self.client.get(f"/repos/{owner}/{repo}/labels", params=params)
+
+    def list_milestones(self, owner: str, repo: str, **params: Any) -> Any | None:
+        return self.client.get(f"/repos/{owner}/{repo}/milestones", params=params)
+
     def get(self, owner: str, repo: str, number: str) -> Any | None:
         return self.client.get(f"/repos/{owner}/{repo}/issues/{number}")
 

--- a/tests/unit/adapters/test_issue_adapter.py
+++ b/tests/unit/adapters/test_issue_adapter.py
@@ -104,16 +104,19 @@ class TestIssueAdapter:
         )
 
     def test_create_issue_normalizes_labels(self, adapter, service):
+        service.list_labels.return_value = [{"name": "bug"}, {"name": "docs"}]
+
         adapter.create_issue(
             "owner",
             "repo",
             title="Bug",
             body="Body",
             assignee="alice",
-            labels=("bug", "docs"),
-            milestone=1,
+            labels=(" bug ", "docs"),
+            milestone="1",
         )
 
+        service.list_labels.assert_called_once_with("owner", "repo", page=1, per_page=100)
         service.create.assert_called_once_with(
             "owner",
             "repo",
@@ -123,6 +126,91 @@ class TestIssueAdapter:
             labels="bug,docs",
             milestone=1,
         )
+
+    def test_create_issue_rejects_unknown_label(self, adapter, service):
+        service.list_labels.return_value = [{"name": "bug"}]
+
+        with pytest.raises(Exception, match="could not add label: 'missing' not found"):
+            adapter.create_issue(
+                "owner",
+                "repo",
+                title="Bug",
+                body="Body",
+                assignee=None,
+                labels=("missing",),
+                milestone=None,
+            )
+
+        service.create.assert_not_called()
+
+    def test_create_issue_resolves_milestone_name(self, adapter, service):
+        service.list_milestones.return_value = [{"title": "v1.0", "number": 7}]
+
+        adapter.create_issue(
+            "owner",
+            "repo",
+            title="Bug",
+            body="Body",
+            assignee=None,
+            labels=None,
+            milestone="v1.0",
+        )
+
+        service.list_milestones.assert_called_once_with("owner", "repo", state="all", page=1, per_page=100)
+        service.create.assert_called_once_with(
+            "owner",
+            "repo",
+            title="Bug",
+            body="Body",
+            assignee=None,
+            labels=None,
+            milestone=7,
+        )
+
+    def test_create_issue_resolves_milestone_name_when_number_is_string(self, adapter, service):
+        service.list_milestones.return_value = [{"title": "v1.0", "number": "7"}]
+
+        adapter.create_issue(
+            "owner",
+            "repo",
+            title="Bug",
+            body="Body",
+            assignee=None,
+            labels=None,
+            milestone="v1.0",
+        )
+
+        service.create.assert_called_once_with(
+            "owner",
+            "repo",
+            title="Bug",
+            body="Body",
+            assignee=None,
+            labels=None,
+            milestone=7,
+        )
+
+    def test_create_issue_reads_label_pages_until_exhausted(self, adapter, service):
+        service.list_labels.side_effect = [
+            [{"name": f"label-{index}"} for index in range(100)],
+            [{"name": "target"}],
+        ]
+
+        adapter.create_issue(
+            "owner",
+            "repo",
+            title="Bug",
+            body="Body",
+            assignee=None,
+            labels=("target",),
+            milestone=None,
+        )
+
+        assert service.list_labels.call_args_list == [
+            call("owner", "repo", page=1, per_page=100),
+            call("owner", "repo", page=2, per_page=100),
+        ]
+        service.create.assert_called_once()
 
     def test_delete_issue_calls_service_delete(self, adapter, service):
         service.delete.return_value = {"success": True}

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -366,16 +366,22 @@ class TestIssueCreate:
 
     def test_rejects_title_longer_than_200_characters(self, runner, mock_client, mock_repo):
         title = "T" * 201
-        result = runner.invoke(main, ["issue", "create", "-t", title])
+        result = runner.invoke(main, ["issue", "create", "-t", title, "-b", "Body"])
         assert result.exit_code != 0
         assert "title must be 200 characters or fewer" in result.output
         mock_client.post.assert_not_called()
 
     def test_allows_title_with_200_characters(self, runner, mock_client, mock_repo):
         title = "T" * 200
-        result = runner.invoke(main, ["issue", "create", "-t", title])
+        result = runner.invoke(main, ["issue", "create", "-t", title, "-b", "Body"])
         assert result.exit_code == 0
         mock_client.post.assert_called_once()
+
+    def test_missing_body_returns_usage_error_before_api_request(self, runner, mock_client, mock_repo):
+        result = runner.invoke(main, ["issue", "create", "-t", "T"])
+        assert result.exit_code != 0
+        assert "--title and --body are required when not running interactively" in result.output
+        mock_client.post.assert_not_called()
 
     def test_web(self, runner, mock_client, mock_repo):
         with patch("gitcode_cli.commands.issue.open_in_browser") as mock_browser:
@@ -391,22 +397,37 @@ class TestIssueCreate:
         mock_browser.assert_called_once_with("https://gitcode.com/owner/repo/issues/new")
 
     def test_alias_new(self, runner, mock_client, mock_repo):
-        result = runner.invoke(main, ["issue", "new", "-t", "T"])
+        result = runner.invoke(main, ["issue", "new", "-t", "T", "-b", "Body"])
         assert result.exit_code == 0
         mock_client.post.assert_called_once()
 
     def test_with_options(self, runner, mock_client, mock_repo):
-        result = runner.invoke(main, ["issue", "create", "-t", "T", "-a", "user", "-l", "bug", "-m", "1"])
+        mock_client.get.return_value = [{"name": "bug"}]
+        result = runner.invoke(main, ["issue", "create", "-t", "T", "-b", "Body", "-a", "user", "-l", "bug", "-m", "1"])
         assert result.exit_code == 0
         json_data = mock_client.post.call_args[1]["json"]
         assert json_data["assignee"] == "user"
         assert json_data["labels"] == "bug"
         assert json_data["milestone"] == 1
 
-    def test_milestone_requires_number(self, runner, mock_client, mock_repo):
-        result = runner.invoke(main, ["issue", "create", "-t", "T", "-m", "v1.0"])
+    def test_unknown_label_returns_error_before_create(self, runner, mock_client, mock_repo):
+        mock_client.get.return_value = [{"name": "bug"}]
+        result = runner.invoke(main, ["issue", "create", "-t", "T", "-b", "Body", "-l", "missing"])
         assert result.exit_code != 0
-        assert "'v1.0' is not a valid integer" in result.output
+        assert "could not add label: 'missing' not found" in result.output
+        mock_client.post.assert_not_called()
+
+    def test_milestone_name_resolves_to_number(self, runner, mock_client, mock_repo):
+        mock_client.get.return_value = [{"title": "v1.0", "number": 7}]
+        result = runner.invoke(main, ["issue", "create", "-t", "T", "-b", "Body", "-m", "v1.0"])
+        assert result.exit_code == 0
+        assert mock_client.post.call_args[1]["json"]["milestone"] == 7
+
+    def test_missing_milestone_name_returns_error_before_create(self, runner, mock_client, mock_repo):
+        mock_client.get.return_value = [{"title": "v2.0", "number": 8}]
+        result = runner.invoke(main, ["issue", "create", "-t", "T", "-b", "Body", "-m", "v1.0"])
+        assert result.exit_code != 0
+        assert "could not resolve milestone: 'v1.0' not found" in result.output
         mock_client.post.assert_not_called()
 
     def test_editor_uses_prompted_title_before_body_editing(self, runner, mock_client, mock_repo, monkeypatch):

--- a/tests/unit/commands/test_issue_adapter_boundary.py
+++ b/tests/unit/commands/test_issue_adapter_boundary.py
@@ -77,7 +77,7 @@ class TestIssueCommandAdapterBoundary:
             mp.setattr("gitcode_cli.commands.issue.IssueAdapter", issue_adapter_ctor)
             result = runner.invoke(
                 main,
-                ["issue", "create", "-t", "Bug", "-b", "Body", "-l", "bug", "-m", "1"],
+                ["issue", "create", "-t", "Bug", "-b", "Body", "-l", "bug", "-m", "v1.0"],
             )
 
         assert result.exit_code == 0
@@ -90,7 +90,7 @@ class TestIssueCommandAdapterBoundary:
             body="Body",
             assignee=None,
             labels=("bug",),
-            milestone=1,
+            milestone="v1.0",
         )
 
     def test_issue_close_delegates_to_adapter(

--- a/tests/unit/services/test_issues.py
+++ b/tests/unit/services/test_issues.py
@@ -34,6 +34,22 @@ class TestIssueService:
         mock_client.get.assert_called_once_with("/user/issues", params={"filter": "assigned", "state": "open"})
         assert result == [{"number": "1"}]
 
+    def test_list_labels(self, service, mock_client):
+        mock_client.get.return_value = [{"name": "bug"}]
+        result = service.list_labels("owner", "repo", per_page=100)
+
+        mock_client.get.assert_called_once_with("/repos/owner/repo/labels", params={"per_page": 100})
+        assert result == [{"name": "bug"}]
+
+    def test_list_milestones(self, service, mock_client):
+        mock_client.get.return_value = [{"title": "v1.0", "number": 7}]
+        result = service.list_milestones("owner", "repo", state="all", per_page=100)
+
+        mock_client.get.assert_called_once_with(
+            "/repos/owner/repo/milestones", params={"state": "all", "per_page": 100}
+        )
+        assert result == [{"title": "v1.0", "number": 7}]
+
     def test_get(self, service, mock_client):
         mock_client.get.return_value = {"number": "42"}
         result = service.get("owner", "repo", "42")


### PR DESCRIPTION
## Description

Fixes `gc issue create` validation gaps by rejecting unknown labels before creation, requiring a body before calling the API, and resolving milestone names to GitCode milestone numbers while still accepting numeric IDs.

## Related Issue

Fixes #103

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

Additional verification run locally via conda environment:

- `conda run -n gitcode-cli ruff check src tests`
- `conda run -n gitcode-cli basedpyright src`
- `conda run -n gitcode-cli pytest tests` (`467 passed`, coverage 92.75%)

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide