### PR TITLE
Fix issue comment gh compatibility gaps

### DIFF
--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -116,7 +116,7 @@ def _resolve_issue_target(app, repo_name: str | None, identifier: str) -> tuple[
 
 
 def _validate_issue_comment_history_flags(
-    *, create_if_none: bool, delete_last: bool, edit_last: bool, yes: bool
+    *, create_if_none: bool, delete_last: bool, edit_last: bool, yes: bool, has_body_source: bool
 ) -> None:
     if create_if_none and not edit_last:
         raise click.UsageError(capability_message("ISSUE_CREATE_IF_NONE_REQUIRES_EDIT_LAST"))
@@ -126,6 +126,8 @@ def _validate_issue_comment_history_flags(
         raise click.UsageError("--yes can only be used together with --delete-last.")
     if edit_last and delete_last:
         raise click.UsageError("Specify only one of --edit-last or --delete-last.")
+    if delete_last and has_body_source:
+        raise click.UsageError("--delete-last cannot be used with --body, --body-file, or --editor.")
 
 
 def _validate_issue_comment_body_sources(*, body: str | None, body_file: str | None, editor: bool, web: bool) -> None:
@@ -470,6 +472,7 @@ def issue_comment(
         delete_last=delete_last,
         edit_last=edit_last,
         yes=yes,
+        has_body_source=body is not None or body_file is not None or editor,
     )
     history_mode = edit_last or delete_last
     body = get_body_from_options(body=body, body_file=body_file, editor=editor)

--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -128,6 +128,22 @@ def _validate_issue_comment_history_flags(
         raise click.UsageError("Specify only one of --edit-last or --delete-last.")
 
 
+def _validate_issue_comment_body_sources(*, body: str | None, body_file: str | None, editor: bool, web: bool) -> None:
+    selected = [body is not None, body_file is not None, editor, web]
+    if sum(selected) > 1:
+        raise click.UsageError("specify only one of --body, --body-file, --editor, or --web")
+
+
+def _issue_comment_url(owner: str, repo: str, number: str, item: dict | None) -> str:
+    if item:
+        if item.get("html_url"):
+            return str(item["html_url"])
+        comment_id = item.get("id")
+        if comment_id is not None:
+            return f"https://gitcode.com/{owner}/{repo}/issues/{number}#issuecomment-{comment_id}"
+    return f"https://gitcode.com/{owner}/{repo}/issues/{number}"
+
+
 def _handle_issue_comment_history(
     *,
     adapter: IssueAdapter,
@@ -140,8 +156,8 @@ def _handle_issue_comment_history(
     create_if_none: bool,
     yes: bool,
 ) -> None:
-    if edit_last:
-        body = prompt_if_missing(body, "Comment")
+    if edit_last and body is None:
+        raise click.UsageError("--body or --body-file is required when not running interactively")
     if delete_last and not yes and not click.confirm("Delete your last issue comment?", default=False):
         raise click.ClickException("Aborted.")
     result = adapter.manage_comment_history(
@@ -156,9 +172,9 @@ def _handle_issue_comment_history(
         safe_echo(f"Deleted last comment on issue #{number}")
         return
     if result.message == "created":
-        safe_echo(result.item.get("html_url") or f"Commented on issue #{number}")
+        safe_echo(_issue_comment_url(owner, repo, number, result.item))
         return
-    safe_echo((result.item or {}).get("html_url") or f"Edited last comment on issue #{number}")
+    safe_echo(_issue_comment_url(owner, repo, number, result.item))
 
 
 @click.group("issue", cls=GCSectionGroup, help="Work with GitCode issues.")
@@ -443,6 +459,7 @@ def issue_comment(
     yes: bool,
 ) -> None:
     app = ctx.obj["app"]
+    _validate_issue_comment_body_sources(body=body, body_file=body_file, editor=editor, web=web)
     owner, repo, number, target_url = _resolve_issue_target(app, repo_name, identifier)
     if web:
         open_in_browser(target_url or f"https://gitcode.com/{owner}/{repo}/issues/{number}")
@@ -478,7 +495,7 @@ def issue_comment(
 
     body = prompt_if_missing(body, "Comment")
     item = adapter.comment_issue(owner, repo, number, body=body)
-    safe_echo(item.get("html_url") or f"Commented on issue #{number}")
+    safe_echo(_issue_comment_url(owner, repo, number, item))
 
 
 @issue_group.command("reopen")
@@ -718,6 +735,15 @@ issue_close.short_help = "Close issue"
 issue_close.help = "Close issue."
 issue_comment.short_help = "Add a comment to an issue"
 issue_comment.help = "Add a comment to an issue."
+set_gc_help(
+    issue_comment,
+    gc_examples=[
+        'gc issue comment 123 --body "I have a question"',
+        "gc issue comment 123 --body-file comment.md",
+        "gc issue comment 123 --edit-last --body-file comment.md",
+        "gc issue comment 123 --web",
+    ],
+)
 issue_reopen.short_help = "Reopen issue"
 issue_reopen.help = "Reopen issue."
 issue_edit.short_help = "Edit issues"

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -571,7 +571,31 @@ class TestIssueComment:
     def test_default(self, runner, mock_client, mock_repo):
         result = runner.invoke(main, ["issue", "comment", "42", "-b", "hi"])
         assert result.exit_code == 0
+        assert "https://example.com/42" in result.output
         mock_client.post.assert_called_once()
+
+    def test_comment_missing_html_url_falls_back_to_comment_anchor(self, runner, mock_client, mock_repo):
+        mock_client.post.return_value = {"id": 99}
+        result = runner.invoke(main, ["issue", "comment", "42", "-b", "hi"])
+        assert result.exit_code == 0
+        assert "https://gitcode.com/owner/repo/issues/42#issuecomment-99" in result.output
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            ["--body", "hi", "--body-file", "comment.md"],
+            ["--body", "hi", "--editor"],
+            ["--body", "hi", "--web"],
+            ["--body-file", "comment.md", "--editor"],
+            ["--body-file", "comment.md", "--web"],
+            ["--editor", "--web"],
+        ],
+    )
+    def test_body_sources_are_mutually_exclusive(self, runner, mock_client, mock_repo, args):
+        result = runner.invoke(main, ["issue", "comment", "42", *args])
+        assert result.exit_code != 0
+        assert "specify only one of --body, --body-file, --editor, or --web" in result.output
+        mock_client.post.assert_not_called()
 
     def test_prompt_body(self, runner, mock_client, mock_repo):
         result = runner.invoke(main, ["issue", "comment", "42"], input="comment body\n")
@@ -620,6 +644,13 @@ class TestIssueComment:
         assert "Issue identifier must be a number or a valid issue URL." in result.output
         mock_client.post.assert_not_called()
 
+    def test_edit_last_requires_body_in_non_interactive_mode(self, runner, mock_client, mock_repo):
+        result = runner.invoke(main, ["issue", "comment", "42", "--edit-last"])
+        assert result.exit_code != 0
+        assert "--body or --body-file is required when not running interactively" in result.output
+        mock_client.get.assert_not_called()
+        mock_client.patch.assert_not_called()
+
     def test_edit_last_updates_last_owned_comment(self, runner, mock_client, mock_repo):
         mock_client.get.side_effect = [
             {"login": "alice"},
@@ -627,6 +658,7 @@ class TestIssueComment:
         ]
         result = runner.invoke(main, ["issue", "comment", "42", "--edit-last", "-b", "new body"])
         assert result.exit_code == 0
+        assert "https://example.com/42" in result.output
         assert mock_client.patch.call_args.kwargs["json"]["body"] == "new body"
         assert "/issues/comments/11" in mock_client.patch.call_args.args[0]
 
@@ -638,7 +670,7 @@ class TestIssueComment:
         mock_client.patch.return_value = None
         result = runner.invoke(main, ["issue", "comment", "42", "--edit-last", "-b", "new body"])
         assert result.exit_code == 0
-        assert "Edited last comment on issue #42" in result.output
+        assert "https://gitcode.com/owner/repo/issues/42" in result.output
 
     def test_edit_last_create_if_none_creates_comment(self, runner, mock_client, mock_repo):
         mock_client.get.side_effect = [
@@ -680,6 +712,12 @@ class TestIssueComment:
         result = runner.invoke(main, ["issue", "comment", "42", "--edit-last", "-b", "new body"])
         assert result.exit_code != 0
         assert "refusing to edit or delete comments safely" in result.output
+
+    def test_help_includes_examples(self, runner):
+        result = runner.invoke(main, ["issue", "comment", "--help"])
+        assert result.exit_code == 0
+        assert "EXAMPLES" in result.output
+        assert 'gc issue comment 123 --body "I have a question"' in result.output
 
 
 class TestIssueReopen:

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -662,6 +662,24 @@ class TestIssueComment:
         assert mock_client.patch.call_args.kwargs["json"]["body"] == "new body"
         assert "/issues/comments/11" in mock_client.patch.call_args.args[0]
 
+    def test_edit_last_editor_updates_last_owned_comment(self, runner, mock_client, mock_repo, monkeypatch):
+        monkeypatch.setattr("gitcode_cli.commands.issue.get_body_from_options", lambda **kwargs: "edited body")
+        mock_client.get.side_effect = [
+            {"login": "alice"},
+            [{"id": 11, "user": {"login": "alice"}, "body": "old"}],
+        ]
+        result = runner.invoke(main, ["issue", "comment", "42", "--edit-last", "--editor"])
+        assert result.exit_code == 0
+        assert mock_client.patch.call_args.kwargs["json"]["body"] == "edited body"
+
+    @pytest.mark.parametrize("args", [["--body", "hi"], ["--body-file", "comment.md"], ["--editor"]])
+    def test_delete_last_rejects_body_sources(self, runner, mock_client, mock_repo, args):
+        result = runner.invoke(main, ["issue", "comment", "42", "--delete-last", "--yes", *args])
+        assert result.exit_code != 0
+        assert "--delete-last cannot be used with --body, --body-file, or --editor." in result.output
+        mock_client.get.assert_not_called()
+        mock_client.delete.assert_not_called()
+
     def test_edit_last_succeeds_when_update_returns_none(self, runner, mock_client, mock_repo):
         mock_client.get.side_effect = [
             {"login": "alice"},


### PR DESCRIPTION
## Description

Fixes `gc issue comment` compatibility gaps with `gh issue comment` by enforcing mutually exclusive body sources, returning comment URLs on success, and surfacing a clear non-interactive `--edit-last` error. Also adds help examples for common comment flows.

## Related Issue

Closes #107

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [ ] Lint passes (`python -m ruff check src/ tests/`)
- [ ] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

Additional verification:

- [x] `conda run -n gitcode-cli pytest` — 488 passed, coverage 92.77%
- [x] Pre-commit hook: `ruff`, `ruff-format`, `basedpyright`, `pytest` passed

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide