### PR TITLE
Fix issue develop validation gaps

### DIFF
--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -625,8 +625,8 @@ def issue_status(
 @issue_group.command("develop")
 @click.option("-R", "--repo", "repo_name", help="Select another repository using the [HOST/]OWNER/REPO format.")
 @click.argument("identifier")
-@click.option("-b", "--base", help="Base branch for the develop branch.")
-@click.option("-n", "--name", help="Name for the local branch.")
+@click.option("-b", "--base", help="Unsupported: GitCode does not provide an issue develop branch API.")
+@click.option("-n", "--name", help="Unsupported: GitCode does not provide an issue develop branch API.")
 @click.pass_context
 def issue_develop(
     ctx: click.Context,
@@ -636,10 +636,6 @@ def issue_develop(
     name: str | None,
 ) -> None:
     app = ctx.obj["app"]
-    if base is not None:
-        raise unsupported("ISSUE_DEVELOP_BASE")
-    if name is not None:
-        raise unsupported("ISSUE_DEVELOP_NAME")
     url_owner, url_repo, number = resolve_issue_arg(identifier)
     if url_owner:
         assert url_repo is not None
@@ -648,6 +644,11 @@ def issue_develop(
         owner, repo = resolve_repo(repo_name or app.repo)
         number = require_issue_number(identifier)
     service = IssueService(app.client())
+    service.get(owner, repo, number)
+    if base is not None:
+        raise unsupported("ISSUE_DEVELOP_BASE")
+    if name is not None:
+        raise unsupported("ISSUE_DEVELOP_NAME")
     adapter = IssueAdapter(service)
     result = adapter.develop(owner, repo, number, base=base, name=name)
     if result.warning:

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -8,6 +8,7 @@ import pytest
 from click.testing import CliRunner
 
 from gitcode_cli.cli import main
+from gitcode_cli.errors import APIError
 
 
 @pytest.fixture
@@ -813,6 +814,17 @@ class TestIssueDevelop:
         assert "does not create a local branch" in result.output
         mock_client.get.assert_called_once_with("/repos/owner/repo/issues/42")
         mock_browser.assert_called_once_with("https://gitcode.com/owner/repo/issues/42")
+
+    def test_develop_does_not_open_browser_when_validation_fails(self, runner, mock_client, mock_repo):
+        mock_client.get.side_effect = APIError("Not Found", status_code=404)
+
+        with patch("gitcode_cli.commands.issue.open_in_browser") as mock_browser:
+            result = runner.invoke(main, ["issue", "develop", "42"])
+
+        assert result.exit_code == 1
+        assert "error: Not Found" in result.output
+        mock_client.get.assert_called_once_with("/repos/owner/repo/issues/42")
+        mock_browser.assert_not_called()
 
     def test_develop_help_marks_branch_options_unsupported(self, runner):
         result = runner.invoke(main, ["issue", "develop", "--help"])

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -806,18 +806,18 @@ class TestIssueDelete:
 
 
 class TestIssueDevelop:
-    def test_develop_opens_browser(self, runner, mock_client, mock_repo):
+    def test_develop_validates_issue_before_opening_browser(self, runner, mock_client, mock_repo):
         with patch("gitcode_cli.commands.issue.open_in_browser") as mock_browser:
             result = runner.invoke(main, ["issue", "develop", "42"])
         assert result.exit_code == 0
         assert "does not create a local branch" in result.output
+        mock_client.get.assert_called_once_with("/repos/owner/repo/issues/42")
         mock_browser.assert_called_once_with("https://gitcode.com/owner/repo/issues/42")
 
-    def test_develop_help(self, runner):
+    def test_develop_help_marks_branch_options_unsupported(self, runner):
         result = runner.invoke(main, ["issue", "develop", "--help"])
         assert result.exit_code == 0
-        assert "Base branch for the develop branch." in result.output
-        assert "Name for the local branch." in result.output
+        assert "Unsupported: GitCode does not provide an issue develop branch API." in result.output
 
     @pytest.mark.parametrize(
         "args",

--- a/tests/unit/commands/test_issue_adapter_boundary.py
+++ b/tests/unit/commands/test_issue_adapter_boundary.py
@@ -121,10 +121,11 @@ class TestIssueCommandAdapterBoundary:
             reason="completed",
         )
 
-    def test_issue_develop_rejects_unsupported_base_before_adapter(
+    def test_issue_develop_rejects_unsupported_base_after_issue_validation(
         self, runner: CliRunner, mock_repo: None, mock_app_client: MagicMock
     ) -> None:
-        issue_service_ctor = MagicMock()
+        service = MagicMock()
+        issue_service_ctor = MagicMock(return_value=service)
         issue_adapter_ctor = MagicMock()
 
         with pytest.MonkeyPatch.context() as mp:
@@ -134,13 +135,15 @@ class TestIssueCommandAdapterBoundary:
 
         assert result.exit_code != 0
         assert "--base" in result.output
-        issue_service_ctor.assert_not_called()
+        issue_service_ctor.assert_called_once_with(mock_app_client)
+        service.get.assert_called_once_with("owner", "repo", "42")
         issue_adapter_ctor.assert_not_called()
 
-    def test_issue_develop_rejects_unsupported_name_before_adapter(
+    def test_issue_develop_rejects_unsupported_name_after_issue_validation(
         self, runner: CliRunner, mock_repo: None, mock_app_client: MagicMock
     ) -> None:
-        issue_service_ctor = MagicMock()
+        service = MagicMock()
+        issue_service_ctor = MagicMock(return_value=service)
         issue_adapter_ctor = MagicMock()
 
         with pytest.MonkeyPatch.context() as mp:
@@ -150,5 +153,6 @@ class TestIssueCommandAdapterBoundary:
 
         assert result.exit_code != 0
         assert "--name" in result.output
-        issue_service_ctor.assert_not_called()
+        issue_service_ctor.assert_called_once_with(mock_app_client)
+        service.get.assert_called_once_with("owner", "repo", "42")
         issue_adapter_ctor.assert_not_called()


### PR DESCRIPTION
## Description

Validate `gc issue develop` targets before opening the browser, so missing issues or repositories surface API errors instead of exiting successfully. Also updates the visible `--base` and `--name` help text to make the GitCode platform limitation explicit.

## Related Issue

Fixes #109

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`conda run -n gitcode-cli pytest`)
- [ ] Lint passes (`python -m ruff check src/ tests/`)
- [ ] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`basedpyright` via pre-commit hook)
- [x] Test coverage remains >= 90%

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide