### PR TITLE
Fix issue delete help and error regression

### DIFF
--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -724,6 +724,7 @@ issue_edit.short_help = "Edit issues"
 issue_edit.help = "Edit issues."
 issue_delete.short_help = "Delete issue"
 issue_delete.help = "Delete issue."
+set_gc_help(issue_delete, gc_usage="gc issue delete {<number> | <url>} [flags]")
 issue_status.short_help = "Show status of relevant issues"
 issue_status.help = "Show status of relevant issues."
 issue_develop.short_help = "Manage linked branches for an issue"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -33,6 +33,11 @@ class TestCli:
         assert "GENERAL COMMANDS" in result.output
         assert "list" in result.output
 
+    def test_cli_issue_delete_help(self, runner):
+        result = runner.invoke(main, ["issue", "delete", "--help"])
+        assert result.exit_code == 0
+        assert "gc issue delete {<number> | <url>} [flags]" in result.output
+
     def test_cli_pr_group(self, runner):
         result = runner.invoke(main, ["pr", "--help"])
         assert result.exit_code == 0
@@ -217,6 +222,20 @@ class TestGlobalErrorHandler:
                 result = runner.invoke(main, ["pr", "view", "999999"])
         assert result.exit_code == 1
         assert "error: Not Found" in result.output
+        assert "Traceback" not in result.output
+
+    def test_issue_delete_api_error_hides_raw_payload_fields(self, runner):
+        with patch("gitcode_cli.cli.get_token", return_value="fake-token"):
+            with patch("gitcode_cli.commands.issue.resolve_repo", return_value=("owner", "repo")):
+                with patch("gitcode_cli.context.AppContext.client") as mock_client_factory:
+                    mock_client = MagicMock()
+                    mock_client.delete.side_effect = APIError("Issue Not Found", status_code=404)
+                    mock_client_factory.return_value = mock_client
+                    result = runner.invoke(main, ["issue", "delete", "999999", "--yes"])
+        assert result.exit_code == 1
+        assert "error: Issue Not Found" in result.output
+        assert "trace_id" not in result.output
+        assert "error_code" not in result.output
         assert "Traceback" not in result.output
 
     def test_gc_error_produces_clean_message_without_traceback(self, runner):


### PR DESCRIPTION
## Description

Fixes the remaining `gc issue delete` compatibility gap by showing the more specific `{<number> | <url>}` usage form, and adds regression coverage for clean API error output that hides raw payload fields.

## Related Issue

Closes #108

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

Ran via commit hooks and verified full unit suite manually:

- `conda run -n gitcode-cli pytest .worktrees/issue-108/tests/unit`

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide