### PR TITLE
Fix issue close gh compatibility

### DIFF
--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -63,6 +63,18 @@ def _echo_issue_status(data: dict[str, list[dict]]) -> None:
         safe_echo("")
 
 
+def _format_issue_reference(item: dict | None, fallback: str) -> str:
+    number = safe_number(item, fallback)
+    title = item.get("title") if isinstance(item, dict) else None
+    return f"#{number} ({title})" if title else f"#{number}"
+
+
+def _normalize_issue_close_reason(reason: str | None) -> str | None:
+    if reason == "not planned":
+        return "not_planned"
+    return reason
+
+
 def _normalize_issue_state(state: object) -> object:
     if not isinstance(state, str):
         return state
@@ -394,7 +406,12 @@ def issue_create(
 @click.argument("identifier")
 @click.option("-c", "--comment", help="Leave a closing comment.")
 @click.option("--duplicate-of", help="Close as a GitCode-limited duplicate approximation by posting a comment first.")
-@click.option("-r", "--reason", type=click.Choice(["completed", "not_planned"]), help="Reason for closing.")
+@click.option(
+    "-r",
+    "--reason",
+    type=click.Choice(["completed", "not_planned", "not planned"]),
+    help="Reason for closing.",
+)
 @click.pass_context
 def issue_close(
     ctx: click.Context,
@@ -418,19 +435,20 @@ def issue_close(
         comment = f"{comment}\n\n{duplicate_comment}" if comment else duplicate_comment
     service = IssueService(app.client())
     adapter = IssueAdapter(service)
-    result = adapter.close_issue(owner, repo, number, comment=comment, reason=reason)
+    result = adapter.close_issue(owner, repo, number, comment=comment, reason=_normalize_issue_close_reason(reason))
     approximation_note = (
         "Note: --duplicate-of is a GitCode-limited approximation; no native duplicate relationship was created."
     )
+    issue_ref = _format_issue_reference(result.item, number)
     if result.message == "already_closed_commented":
-        safe_echo(f"Issue #{safe_number(result.item, number)} is already closed; posted comment")
+        safe_echo(f"Issue {issue_ref} is already closed; posted comment")
         if approximated:
             safe_echo(approximation_note)
         return
     if result.message == "already_closed":
-        safe_echo(f"Issue #{safe_number(result.item, number)} is already closed")
+        safe_echo(f"Issue {issue_ref} is already closed")
         return
-    safe_echo(f"Closed issue #{safe_number(result.item, number)}")
+    safe_echo(f"Closed issue {issue_ref}")
     if approximated:
         safe_echo(approximation_note)
 

--- a/tests/unit/commands/test_issue_adapter_boundary.py
+++ b/tests/unit/commands/test_issue_adapter_boundary.py
@@ -121,6 +121,34 @@ class TestIssueCommandAdapterBoundary:
             reason="completed",
         )
 
+    def test_issue_close_accepts_gh_not_planned_reason(
+        self, runner: CliRunner, mock_repo: None, mock_app_client: MagicMock
+    ) -> None:
+        adapter = MagicMock()
+        adapter.close_issue.return_value = type(
+            "Result",
+            (),
+            {"message": "closed", "item": {"number": "42", "title": "Bug title"}},
+        )()
+
+        issue_service_ctor = MagicMock()
+        issue_adapter_ctor = MagicMock(return_value=adapter)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr("gitcode_cli.commands.issue.IssueService", issue_service_ctor)
+            mp.setattr("gitcode_cli.commands.issue.IssueAdapter", issue_adapter_ctor)
+            result = runner.invoke(main, ["issue", "close", "42", "-r", "not planned"])
+
+        assert result.exit_code == 0
+        assert "Closed issue #42 (Bug title)" in result.output
+        adapter.close_issue.assert_called_once_with(
+            "owner",
+            "repo",
+            "42",
+            comment=None,
+            reason="not_planned",
+        )
+
     def test_issue_develop_rejects_unsupported_base_after_issue_validation(
         self, runner: CliRunner, mock_repo: None, mock_app_client: MagicMock
     ) -> None:


### PR DESCRIPTION
## Description

Fixes `gc issue close` compatibility gaps with `gh issue close` by accepting the gh-style `--reason "not planned"` value and including the issue title in successful close output when the API response provides it.

## Related Issue

Closes #106

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

Commands run via pre-commit hook during commit:
- `ruff`
- `ruff-format`
- `basedpyright`
- `pytest`

Additional verification:
- `conda run -n gitcode-cli pytest --no-cov .worktrees/issue-106/tests/unit/commands/test_issue_adapter_boundary.py .worktrees/issue-106/tests/unit/test_client.py` — 24 passed
- `conda run -n gitcode-cli pytest .worktrees/issue-106/tests/unit` — 464 passed, coverage 92.70%

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide