### PR TITLE
Fix issue edit remove flags and URL output

### DIFF
--- a/src/gitcode_cli/adapters/issues.py
+++ b/src/gitcode_cli/adapters/issues.py
@@ -292,6 +292,8 @@ class IssueAdapter:
         body: str | None,
         add_assignee: str | None,
         add_labels: tuple[str, ...] | None,
+        remove_assignee: str | None,
+        remove_labels: tuple[str, ...] | None,
         milestone: int | None,
         remove_milestone: bool,
     ) -> dict[str, Any] | None:
@@ -299,15 +301,18 @@ class IssueAdapter:
 
         if add_assignee is not None:
             data["assignee"] = add_assignee
+        if remove_assignee is not None:
+            data["assignee"] = ""
 
-        if add_labels:
+        if add_labels or remove_labels:
             current = self.service.get(owner, repo, number)
             existing = _extract_label_names(current)
+            removed = {label.strip() for label in remove_labels or () if label.strip()}
             merged: list[str] = []
             seen: set[str] = set()
-            for label in [*existing, *list(add_labels)]:
+            for label in [*existing, *list(add_labels or ())]:
                 normalized = label.strip()
-                if normalized and normalized not in seen:
+                if normalized and normalized not in removed and normalized not in seen:
                     seen.add(normalized)
                     merged.append(normalized)
             data["labels"] = ",".join(merged)

--- a/src/gitcode_cli/adapters/issues.py
+++ b/src/gitcode_cli/adapters/issues.py
@@ -42,6 +42,30 @@ def _extract_label_names(issue: dict[str, Any] | None) -> list[str]:
     return names
 
 
+def _extract_assignee_names(issue: dict[str, Any] | None) -> list[str]:
+    assignees = issue.get("assignees") if isinstance(issue, dict) else None
+    if isinstance(assignees, str):
+        return [part.strip() for part in assignees.split(",") if part.strip()]
+    if isinstance(assignees, list):
+        names: list[str] = []
+        for assignee in assignees:
+            if isinstance(assignee, dict):
+                name = _extract_login(assignee)
+                if name:
+                    names.append(name)
+            elif assignee:
+                names.append(str(assignee))
+        return names
+
+    assignee = issue.get("assignee") if isinstance(issue, dict) else None
+    if isinstance(assignee, str):
+        return [part.strip() for part in assignee.split(",") if part.strip()]
+    if isinstance(assignee, dict):
+        name = _extract_login(assignee)
+        return [name] if name else []
+    return []
+
+
 def _matches_all_labels(issue: dict[str, Any], labels: tuple[str, ...] | None) -> bool:
     if not labels or len(labels) < 2:
         return True
@@ -302,7 +326,9 @@ class IssueAdapter:
         if add_assignee is not None:
             data["assignee"] = add_assignee
         if remove_assignee is not None:
-            data["assignee"] = ""
+            current = self.service.get(owner, repo, number)
+            remaining = [name for name in _extract_assignee_names(current) if name != remove_assignee]
+            data["assignee"] = ",".join(remaining)
 
         if add_labels or remove_labels:
             current = self.service.get(owner, repo, number)

--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -571,10 +571,6 @@ def issue_edit(
     remove_labels: tuple[str, ...] | None,
     remove_milestone: bool,
 ) -> None:
-    if remove_assignee is not None:
-        _pending_gh_compat("issue edit --remove-assignee")
-    if remove_labels:
-        _pending_gh_compat("issue edit --remove-label")
     app = ctx.obj["app"]
     url_owner, url_repo, number = resolve_issue_arg(identifier)
     if url_owner:
@@ -607,10 +603,12 @@ def issue_edit(
         body=body,
         add_assignee=add_assignee,
         add_labels=add_labels,
+        remove_assignee=remove_assignee,
+        remove_labels=remove_labels,
         milestone=milestone,
         remove_milestone=remove_milestone,
     )
-    safe_echo(f"Edited issue #{safe_number(item, number)}")
+    safe_echo((item or {}).get("html_url") or f"Edited issue #{safe_number(item, number)}")
 
 
 @issue_group.command("delete")

--- a/tests/unit/adapters/test_issue_adapter.py
+++ b/tests/unit/adapters/test_issue_adapter.py
@@ -329,7 +329,29 @@ class TestIssueAdapter:
 
         service.update.assert_called_once_with("owner", "repo", "42", labels="existing,docs")
 
-    def test_edit_issue_remove_assignee_sends_empty_assignee(self, adapter, service):
+    def test_edit_issue_adds_and_removes_labels(self, adapter, service):
+        service.get.return_value = {"labels": [{"name": "existing"}, {"name": "bug"}]}
+        service.update.return_value = {"number": "42"}
+
+        adapter.edit_issue(
+            "owner",
+            "repo",
+            "42",
+            title=None,
+            body=None,
+            add_assignee=None,
+            add_labels=("docs",),
+            remove_assignee=None,
+            remove_labels=("bug",),
+            milestone=None,
+            remove_milestone=False,
+        )
+
+        service.update.assert_called_once_with("owner", "repo", "42", labels="existing,docs")
+
+    def test_edit_issue_removes_assignee_from_existing_assignees(self, adapter, service):
+        service.get.return_value = {"assignee": "alice,bob"}
+
         adapter.edit_issue(
             "owner",
             "repo",
@@ -338,13 +360,13 @@ class TestIssueAdapter:
             body=None,
             add_assignee=None,
             add_labels=None,
-            remove_assignee="user",
+            remove_assignee="bob",
             remove_labels=None,
             milestone=None,
             remove_milestone=False,
         )
 
-        service.update.assert_called_once_with("owner", "repo", "42", assignee="")
+        service.update.assert_called_once_with("owner", "repo", "42", assignee="alice")
 
     def test_edit_issue_sets_milestone_number(self, adapter, service):
         adapter.edit_issue(

--- a/tests/unit/adapters/test_issue_adapter.py
+++ b/tests/unit/adapters/test_issue_adapter.py
@@ -301,11 +301,50 @@ class TestIssueAdapter:
             body=None,
             add_assignee=None,
             add_labels=("bug", "docs"),
+            remove_assignee=None,
+            remove_labels=None,
             milestone=None,
             remove_milestone=False,
         )
 
         service.update.assert_called_once_with("owner", "repo", "42", labels="existing,bug,docs")
+
+    def test_edit_issue_removes_labels(self, adapter, service):
+        service.get.return_value = {"labels": [{"name": "existing"}, {"name": "bug"}, {"name": "docs"}]}
+        service.update.return_value = {"number": "42"}
+
+        adapter.edit_issue(
+            "owner",
+            "repo",
+            "42",
+            title=None,
+            body=None,
+            add_assignee=None,
+            add_labels=None,
+            remove_assignee=None,
+            remove_labels=("bug",),
+            milestone=None,
+            remove_milestone=False,
+        )
+
+        service.update.assert_called_once_with("owner", "repo", "42", labels="existing,docs")
+
+    def test_edit_issue_remove_assignee_sends_empty_assignee(self, adapter, service):
+        adapter.edit_issue(
+            "owner",
+            "repo",
+            "42",
+            title=None,
+            body=None,
+            add_assignee=None,
+            add_labels=None,
+            remove_assignee="user",
+            remove_labels=None,
+            milestone=None,
+            remove_milestone=False,
+        )
+
+        service.update.assert_called_once_with("owner", "repo", "42", assignee="")
 
     def test_edit_issue_sets_milestone_number(self, adapter, service):
         adapter.edit_issue(
@@ -316,6 +355,8 @@ class TestIssueAdapter:
             body=None,
             add_assignee=None,
             add_labels=None,
+            remove_assignee=None,
+            remove_labels=None,
             milestone=1,
             remove_milestone=False,
         )
@@ -331,6 +372,8 @@ class TestIssueAdapter:
             body=None,
             add_assignee=None,
             add_labels=None,
+            remove_assignee=None,
+            remove_labels=None,
             milestone=None,
             remove_milestone=True,
         )

--- a/tests/unit/commands/test_cli_gh_compat.py
+++ b/tests/unit/commands/test_cli_gh_compat.py
@@ -169,8 +169,6 @@ class TestCliGhCompatibility:
             (["pr", "comment", "1", "--delete-last"], "pr comment --delete-last"),
             (["pr", "comment", "1", "--edit-last"], "pr comment --edit-last"),
             (["pr", "comment", "1", "--yes"], "pr comment --yes"),
-            (["issue", "edit", "1", "--remove-assignee", "monalisa"], "issue edit --remove-assignee"),
-            (["issue", "edit", "1", "--remove-label", "bug"], "issue edit --remove-label"),
             (["issue", "reopen", "1", "--comment", "reopening"], "issue reopen --comment"),
             (["pr", "reopen", "1", "--comment", "reopening"], "pr reopen --comment"),
             (["pr", "diff", "1", "--name-only"], "pr diff --name-only"),

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -772,7 +772,7 @@ class TestIssueEdit:
     def test_default(self, runner, mock_client, mock_repo):
         result = runner.invoke(main, ["issue", "edit", "42", "-t", "New", "-b", "New body"])
         assert result.exit_code == 0
-        assert "Edited issue #42" in result.output
+        assert "https://example.com/42" in result.output
         json_data = mock_client.patch.call_args[1]["json"]
         assert json_data["title"] == "New"
         assert json_data["body"] == "New body"
@@ -789,6 +789,19 @@ class TestIssueEdit:
         assert result.exit_code == 0
         json_data = mock_client.patch.call_args[1]["json"]
         assert json_data["labels"] == "bug,docs"
+
+    def test_remove_assignee(self, runner, mock_client, mock_repo):
+        result = runner.invoke(main, ["issue", "edit", "42", "--remove-assignee", "user"])
+        assert result.exit_code == 0
+        json_data = mock_client.patch.call_args[1]["json"]
+        assert json_data["assignee"] == ""
+
+    def test_remove_label(self, runner, mock_client, mock_repo):
+        mock_client.get.return_value = {"labels": [{"name": "bug"}, {"name": "docs"}]}
+        result = runner.invoke(main, ["issue", "edit", "42", "--remove-label", "bug"])
+        assert result.exit_code == 0
+        json_data = mock_client.patch.call_args[1]["json"]
+        assert json_data["labels"] == "docs"
 
     def test_milestone_requires_number(self, runner, mock_client, mock_repo):
         result = runner.invoke(main, ["issue", "edit", "42", "-m", "v1.0"])


### PR DESCRIPTION
## Description

Fixes `gc issue edit` gh-compat gaps by implementing `--remove-assignee` and `--remove-label`, and by printing the edited issue URL when the API response includes `html_url`.

## Related Issue

Fixes #110

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

Commands run:

- `conda run -n gitcode-cli python -m pytest --no-cov tests/unit/commands/test_issue.py::TestIssueEdit tests/unit/adapters/test_issue_adapter.py tests/unit/commands/test_cli_gh_compat.py`
- `conda run -n gitcode-cli python -m pytest`
- pre-commit hook: `ruff`, `ruff-format`, `basedpyright`, `pytest`

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide