### PR TITLE
Fix issue view gh-compatible output gaps

### DIFF
--- a/src/gitcode_cli/commands/issue.py
+++ b/src/gitcode_cli/commands/issue.py
@@ -91,15 +91,16 @@ def _normalize_issue_author(item: dict) -> object:
     }
 
 
+def _normalize_issue_item(item: dict) -> dict:
+    normalized_item = dict(item)
+    normalized_item["number"] = _normalize_issue_number(normalized_item.get("number"))
+    normalized_item["state"] = _normalize_issue_state(normalized_item.get("state"))
+    normalized_item["author"] = _normalize_issue_author(normalized_item)
+    return normalized_item
+
+
 def _normalize_issue_list_items(items: list[dict]) -> list[dict]:
-    normalized = []
-    for item in items:
-        normalized_item = dict(item)
-        normalized_item["number"] = _normalize_issue_number(normalized_item.get("number"))
-        normalized_item["state"] = _normalize_issue_state(normalized_item.get("state"))
-        normalized_item["author"] = _normalize_issue_author(normalized_item)
-        normalized.append(normalized_item)
-    return normalized
+    return [_normalize_issue_item(item) for item in items]
 
 
 def _pending_gh_compat(name: str) -> None:
@@ -274,9 +275,10 @@ def issue_view(
         return
     service = IssueService(app.client())
     item = service.get(owner, repo, number)
+    output_item = _normalize_issue_item(item) if item and (json_fields or jq_query or template) else item
     if comments:
         comment_items = service.list_comments(owner, repo, number)
-        data = dict(item) if item else {}
+        data = dict(output_item) if output_item else {}
         data["comments"] = comment_items
 
         def default_formatter(data: dict) -> None:
@@ -295,7 +297,7 @@ def issue_view(
         )
         return
     output_result(
-        item,
+        output_item,
         json_fields,
         jq_query,
         template,

--- a/src/gitcode_cli/formatters.py
+++ b/src/gitcode_cli/formatters.py
@@ -121,19 +121,26 @@ def _parse_jq_output(stdout: str):
 def apply_jq(data, query: str):
     try:
         import jq  # noqa: PLC0415
-
-        return jq.compile(query).input(data).all()
     except ImportError:
         pass
+    else:
+        try:
+            return jq.compile(query).input(data).all()
+        except Exception as exc:
+            raise click.ClickException(f"jq expression error: {exc}") from exc
     jq_bin = shutil.which("jq")
     if jq_bin:
-        proc = subprocess.run(
-            [jq_bin, "-c", query],
-            input=json.dumps(data),
-            capture_output=True,
-            text=True,
-            check=True,
-        )
+        try:
+            proc = subprocess.run(
+                [jq_bin, "-c", query],
+                input=json.dumps(data),
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            message = (exc.stderr or exc.stdout or str(exc)).strip()
+            raise click.ClickException(f"jq expression error: {message}") from exc
         return _parse_jq_output(proc.stdout)
     raise click.ClickException("jq is required for --jq. Install with: pip install pyjq or install jq CLI.")
 

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -226,10 +227,25 @@ class TestIssueView:
         mock_client.get.assert_called_with("/repos/owner/repo/issues/42")
 
     def test_json(self, runner, mock_client, mock_repo):
-        mock_client.get.return_value = {"number": "42", "title": "Test"}
-        result = runner.invoke(main, ["issue", "view", "42", "--json", "number"])
+        mock_client.get.return_value = {
+            "number": "42",
+            "title": "Test",
+            "state": "opened",
+            "user": {"id": 7, "login": "alice"},
+        }
+        result = runner.invoke(main, ["issue", "view", "42", "--json", "number,state,author"])
         assert result.exit_code == 0
-        assert '"number"' in result.output
+        assert json.loads(result.output) == {
+            "number": 42,
+            "state": "OPEN",
+            "author": {"id": 7, "is_bot": False, "login": "alice", "name": "alice"},
+        }
+
+    def test_jq_uses_single_normalized_issue(self, runner, mock_client, mock_repo):
+        mock_client.get.return_value = {"number": "42", "title": "Test", "user": {"login": "alice"}}
+        result = runner.invoke(main, ["issue", "view", "42", "--jq", ".author.login"])
+        assert result.exit_code == 0
+        assert json.loads(result.output) == "alice"
 
     def test_comments_json_includes_comments(self, runner, mock_client, mock_repo):
         mock_client.get.side_effect = [
@@ -241,7 +257,7 @@ class TestIssueView:
         ]
         result = runner.invoke(main, ["issue", "view", "42", "--comments", "--json", "number,comments"])
         assert result.exit_code == 0
-        assert '"number": "42"' in result.output
+        assert '"number": 42' in result.output
         assert '"comments"' in result.output
         assert '"First comment"' in result.output
         assert '"Second comment"' in result.output

--- a/tests/unit/test_formatters.py
+++ b/tests/unit/test_formatters.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from unittest.mock import MagicMock
 
 import click
@@ -234,6 +235,13 @@ class TestApplyJq:
         result = apply_jq({"id": 1}, ".id")
         assert result == [{"id": 1}]
 
+    def test_pyjq_error_raises_click_exception(self, mocker):
+        mock_jq_module = MagicMock()
+        mock_jq_module.compile.side_effect = ValueError("invalid filter")
+        mocker.patch.dict("sys.modules", {"jq": mock_jq_module})
+        with pytest.raises(click.ClickException, match="jq expression error: invalid filter"):
+            apply_jq({"id": 1}, ".id | @tsv")
+
     def test_jq_cli_success(self, mocker):
         mocker.patch.dict("sys.modules", {"jq": None})
         mock_run = mocker.patch("gitcode_cli.formatters.subprocess.run")
@@ -265,6 +273,16 @@ class TestApplyJq:
         mocker.patch("gitcode_cli.formatters.shutil.which", return_value="/usr/bin/jq")
         result = apply_jq({"id": 1}, "empty")
         assert result == []
+
+    def test_jq_cli_error_raises_click_exception(self, mocker):
+        mocker.patch.dict("sys.modules", {"jq": None})
+        mocker.patch("gitcode_cli.formatters.shutil.which", return_value="/usr/bin/jq")
+        mocker.patch(
+            "gitcode_cli.formatters.subprocess.run",
+            side_effect=subprocess.CalledProcessError(5, ["jq"], stderr="invalid filter"),
+        )
+        with pytest.raises(click.ClickException, match="jq expression error: invalid filter"):
+            apply_jq({"id": 1}, ".id | @tsv")
 
     def test_jq_not_available_raises_click_exception(self, mocker):
         mocker.patch.dict("sys.modules", {"jq": None})


### PR DESCRIPTION
## Description

- Normalize `gc issue view` machine-readable output as a single issue object.
- Map issue `number`, `state`, and `author` fields for gh-compatible JSON/jq/template output.
- Wrap Python jq and jq CLI expression failures in friendly Click errors.

## Related Issue

Fixes #112

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

Pre-commit hooks passed for ruff, ruff-format, basedpyright, and pytest.
Manual verification: `conda run -n gitcode-cli pytest /Users/test1/liuyekang/dev/cli/gitcode-cli/.worktrees/issue-112/tests` passed with 482 tests and 92.80% coverage before commit.

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide