### PR TITLE
Ignore generated local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ Thumbs.db
 .claude/
 .trae/
 .omc/
+output/
+**/AGENTS.md


### PR DESCRIPTION
## Description

Ignore generated local artifacts so workspace-only OMC/agent outputs do not appear in Git status.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [x] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [ ] Lint passes (`python -m ruff check src/ tests/`)
- [ ] Format passes (`python -m ruff format --check src/ tests/`)
- [ ] Type check passes (`python -m basedpyright src/`)
- [ ] Test coverage remains >= 90%

Pre-commit hooks ran on commit: ruff, ruff-format, basedpyright were skipped because no relevant files changed; pytest passed.

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [ ] I have added tests that prove my fix/feature works
- [ ] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide