### PR TITLE
Support PR merged-time search filters

### DIFF
--- a/src/gitcode_cli/adapters/pulls.py
+++ b/src/gitcode_cli/adapters/pulls.py
@@ -31,19 +31,24 @@ class PullRequestAdapter:
         labels: tuple[str, ...] | None,
         search: str | None,
         limit: int | None,
+        merged_after: str | None = None,
+        merged_before: str | None = None,
     ) -> Any:
-        items = self.service.list(
-            owner,
-            repo,
-            state=state,
-            author=author,
-            base=base,
-            assignee=assignee,
-            draft=draft,
-            head=head,
-            labels=_normalize_multi_values(labels),
-            search=search,
-        )
+        params = {
+            "state": state,
+            "author": author,
+            "base": base,
+            "assignee": assignee,
+            "draft": draft,
+            "head": head,
+            "labels": _normalize_multi_values(labels),
+            "search": search,
+        }
+        if merged_after is not None:
+            params["merged_after"] = merged_after
+        if merged_before is not None:
+            params["merged_before"] = merged_before
+        items = self.service.list(owner, repo, **params)
         if limit is not None:
             return items[:limit]
         return items

--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -61,7 +61,9 @@ def _split_merged_range(value: str) -> tuple[str | None, str | None]:
     return value, value
 
 
-def _extract_search_filters(search: str | None, state: str | None) -> tuple[str | None, str | None, str | None, str | None]:
+def _extract_search_filters(
+    search: str | None, state: str | None
+) -> tuple[str | None, str | None, str | None, str | None]:
     if not search:
         return search, state, None, None
     remaining = search

--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 
 import click
@@ -31,6 +32,43 @@ from ..utils import (
 
 def _pending_gh_compat(name: str) -> None:
     raise click.ClickException(f"gh-compatible command/flag '{name}' is recognized but not implemented yet.")
+
+
+def _pr_merged_at(item: dict) -> str | None:
+    value = item.get("mergedAt") or item.get("merged_at")
+    return str(value) if value else None
+
+
+def _normalize_pr_fields(item: dict) -> dict:
+    result = dict(item)
+    if "mergedAt" not in result:
+        result["mergedAt"] = _pr_merged_at(item)
+    return result
+
+
+def _split_merged_range(value: str) -> tuple[str | None, str | None]:
+    if ".." in value:
+        after, before = value.split("..", 1)
+        return after or None, before or None
+    return value, value
+
+
+def _extract_search_filters(search: str | None, state: str | None) -> tuple[str | None, str | None, str | None, str | None]:
+    if not search:
+        return search, state, None, None
+    remaining = search
+    merged_after = None
+    merged_before = None
+    for match in re.finditer(r"(?:^|\s)merged:(\S+)", search):
+        after, before = _split_merged_range(match.group(1))
+        merged_after = after
+        merged_before = before
+        remaining = remaining.replace(match.group(0), " ", 1)
+    if re.search(r"(?:^|\s)is:merged(?:\s|$)", search):
+        state = "merged"
+        remaining = re.sub(r"(?:^|\s)is:merged(?=\s|$)", " ", remaining)
+    normalized_search = " ".join(remaining.split()) or None
+    return normalized_search, state, merged_after, merged_before
 
 
 @click.group("pr", cls=GCSectionGroup, help="Work with GitCode pull requests.")
@@ -342,6 +380,7 @@ def pr_list(
         return
     service = PullRequestService(app.client())
     adapter = PullRequestAdapter(service)
+    search, state, merged_after, merged_before = _extract_search_filters(search, state)
     items = adapter.list_prs(
         owner,
         repo,
@@ -354,7 +393,10 @@ def pr_list(
         labels=labels,
         search=search,
         limit=limit,
+        merged_after=merged_after,
+        merged_before=merged_before,
     )
+    items = [_normalize_pr_fields(item) for item in items]
 
     def default_formatter(data):
         output = format_pr_list(data)
@@ -744,6 +786,7 @@ set_gc_help(
         "createdAt",
         "headRefName",
         "labels",
+        "mergedAt",
         "number",
         "state",
         "title",

--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -49,7 +49,15 @@ def _normalize_pr_fields(item: dict) -> dict:
 def _split_merged_range(value: str) -> tuple[str | None, str | None]:
     if ".." in value:
         after, before = value.split("..", 1)
-        return after or None, before or None
+        return (after if after and after != "*" else None), (before if before and before != "*" else None)
+    if value.startswith(">="):
+        return value[2:], None
+    if value.startswith(">"):
+        return value[1:], None
+    if value.startswith("<="):
+        return None, value[2:]
+    if value.startswith("<"):
+        return None, value[1:]
     return value, value
 
 
@@ -381,21 +389,22 @@ def pr_list(
     service = PullRequestService(app.client())
     adapter = PullRequestAdapter(service)
     search, state, merged_after, merged_before = _extract_search_filters(search, state)
-    items = adapter.list_prs(
-        owner,
-        repo,
-        state=state,
-        author=author,
-        base=base,
-        assignee=assignee,
-        draft=draft,
-        head=head,
-        labels=labels,
-        search=search,
-        limit=limit,
-        merged_after=merged_after,
-        merged_before=merged_before,
-    )
+    list_kwargs = {
+        "state": state,
+        "author": author,
+        "base": base,
+        "assignee": assignee,
+        "draft": draft,
+        "head": head,
+        "labels": labels,
+        "search": search,
+        "limit": limit,
+    }
+    if merged_after is not None:
+        list_kwargs["merged_after"] = merged_after
+    if merged_before is not None:
+        list_kwargs["merged_before"] = merged_before
+    items = adapter.list_prs(owner, repo, **list_kwargs)
     items = [_normalize_pr_fields(item) for item in items]
 
     def default_formatter(data):

--- a/src/gitcode_cli/formatters.py
+++ b/src/gitcode_cli/formatters.py
@@ -20,6 +20,8 @@ def dump_json(data, fields: list[str] | None = None) -> str:
 
 
 def _field_value(item: dict, field: str):
+    if field == "mergedAt":
+        return item.get("mergedAt") or item.get("merged_at")
     if "." in field:
         parts = field.split(".")
         value = item

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -178,25 +178,53 @@ class TestPrList:
         )
         assert '"mergedAt": "2026-05-28T16:00:00+08:00"' in result.output
 
-    def test_pr_list_search_is_merged_sets_state_when_state_omitted(self, runner, mock_client, mock_repo):
-        mock_client.get.return_value = []
-        result = runner.invoke(main, ["pr", "list", "--search", "author:alice is:merged merged:2026-05-28"])
+    @pytest.mark.parametrize(
+        ("search", "expected_search", "expected_params"),
+        [
+            ("is:merged", None, {"state": "merged"}),
+            ("merged:2026-05-28", None, {"merged_after": "2026-05-28", "merged_before": "2026-05-28"}),
+            ("merged:>2026-05-28", None, {"merged_after": "2026-05-28"}),
+            ("merged:>=2026-05-28", None, {"merged_after": "2026-05-28"}),
+            ("merged:<2026-05-28", None, {"merged_before": "2026-05-28"}),
+            ("merged:<=2026-05-28", None, {"merged_before": "2026-05-28"}),
+            (
+                "merged:2026-05-01..2026-05-30",
+                None,
+                {"merged_after": "2026-05-01", "merged_before": "2026-05-30"},
+            ),
+            ("merged:2026-05-01..*", None, {"merged_after": "2026-05-01"}),
+            ("merged:*..2026-05-30", None, {"merged_before": "2026-05-30"}),
+            ("author:alice is:merged merged:2026-05-28", "author:alice", {"state": "merged", "merged_after": "2026-05-28", "merged_before": "2026-05-28"}),
+        ],
+    )
+    def test_pr_list_maps_gh_merged_search_qualifiers(
+        self, runner, mock_client, mock_repo, search, expected_search, expected_params
+    ):
+        result = runner.invoke(main, ["pr", "list", "--search", search])
         assert result.exit_code == 0
-        assert mock_client.get.call_args == call(
-            "/repos/owner/repo/pulls",
-            params={
-                "state": "merged",
-                "author": None,
-                "base": None,
-                "assignee": None,
-                "draft": None,
-                "head": None,
-                "labels": None,
-                "search": "author:alice",
-                "merged_after": "2026-05-28",
-                "merged_before": "2026-05-28",
-            },
-        )
+        params = mock_client.get.call_args.kwargs["params"]
+        assert params | expected_params == params
+        assert params["search"] == expected_search
+
+    def test_pr_list_merged_search_preserves_explicit_state_without_is_merged(self, runner, mock_client, mock_repo):
+        result = runner.invoke(main, ["pr", "list", "--state", "all", "--search", "merged:>=2026-05-28"])
+        assert result.exit_code == 0
+        assert mock_client.get.call_args.kwargs["params"]["state"] == "all"
+        assert mock_client.get.call_args.kwargs["params"]["merged_after"] == "2026-05-28"
+
+    def test_pr_list_is_merged_search_overrides_state(self, runner, mock_client, mock_repo):
+        result = runner.invoke(main, ["pr", "list", "--state", "all", "--search", "is:merged"])
+        assert result.exit_code == 0
+        assert mock_client.get.call_args.kwargs["params"]["state"] == "merged"
+
+    def test_pr_list_json_includes_api_merged_at_field(self, runner, mock_client, mock_repo):
+        mock_client.get.return_value = [
+            {"number": 1, "title": "First PR", "merged_at": "2026-05-28T12:00:00+08:00"},
+        ]
+        result = runner.invoke(main, ["pr", "list", "--json", "number,title,merged_at"])
+        assert result.exit_code == 0
+        assert '"merged_at": "2026-05-28T12:00:00+08:00"' in result.output
+
 
     def test_pr_list_template_with_json_uses_template(self, runner, mock_client, mock_repo):
         mock_client.get.return_value = [

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -132,6 +132,72 @@ class TestPrList:
         assert '"number": 1' in result.output
         assert '"title": "First PR"' in result.output
 
+    def test_pr_list_json_includes_merged_at_alias(self, runner, mock_client, mock_repo):
+        mock_client.get.return_value = [
+            {"number": 1, "merged_at": "2026-05-28T16:00:00+08:00"},
+        ]
+        result = runner.invoke(main, ["pr", "list", "--json", "number,mergedAt"])
+        assert result.exit_code == 0
+        assert '"number": 1' in result.output
+        assert '"mergedAt": "2026-05-28T16:00:00+08:00"' in result.output
+
+    def test_pr_list_search_merged_range_maps_to_api_filters(self, runner, mock_client, mock_repo):
+        mock_client.get.return_value = [
+            {"number": 1, "title": "In range", "merged_at": "2026-05-28T16:00:00+08:00"},
+        ]
+        result = runner.invoke(
+            main,
+            [
+                "pr",
+                "list",
+                "--state",
+                "all",
+                "--search",
+                "is:merged merged:2026-05-28T14:00:00+08:00..2026-05-28T20:00:00+08:00",
+                "--limit",
+                "100",
+                "--json",
+                "number,title,mergedAt",
+            ],
+        )
+        assert result.exit_code == 0
+        assert mock_client.get.call_args == call(
+            "/repos/owner/repo/pulls",
+            params={
+                "state": "merged",
+                "author": None,
+                "base": None,
+                "assignee": None,
+                "draft": None,
+                "head": None,
+                "labels": None,
+                "search": None,
+                "merged_after": "2026-05-28T14:00:00+08:00",
+                "merged_before": "2026-05-28T20:00:00+08:00",
+            },
+        )
+        assert '"mergedAt": "2026-05-28T16:00:00+08:00"' in result.output
+
+    def test_pr_list_search_is_merged_sets_state_when_state_omitted(self, runner, mock_client, mock_repo):
+        mock_client.get.return_value = []
+        result = runner.invoke(main, ["pr", "list", "--search", "author:alice is:merged merged:2026-05-28"])
+        assert result.exit_code == 0
+        assert mock_client.get.call_args == call(
+            "/repos/owner/repo/pulls",
+            params={
+                "state": "merged",
+                "author": None,
+                "base": None,
+                "assignee": None,
+                "draft": None,
+                "head": None,
+                "labels": None,
+                "search": "author:alice",
+                "merged_after": "2026-05-28",
+                "merged_before": "2026-05-28",
+            },
+        )
+
     def test_pr_list_template_with_json_uses_template(self, runner, mock_client, mock_repo):
         mock_client.get.return_value = [
             {"number": 1, "title": "First PR"},

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -194,7 +194,11 @@ class TestPrList:
             ),
             ("merged:2026-05-01..*", None, {"merged_after": "2026-05-01"}),
             ("merged:*..2026-05-30", None, {"merged_before": "2026-05-30"}),
-            ("author:alice is:merged merged:2026-05-28", "author:alice", {"state": "merged", "merged_after": "2026-05-28", "merged_before": "2026-05-28"}),
+            (
+                "author:alice is:merged merged:2026-05-28",
+                "author:alice",
+                {"state": "merged", "merged_after": "2026-05-28", "merged_before": "2026-05-28"},
+            ),
         ],
     )
     def test_pr_list_maps_gh_merged_search_qualifiers(
@@ -224,7 +228,6 @@ class TestPrList:
         result = runner.invoke(main, ["pr", "list", "--json", "number,title,merged_at"])
         assert result.exit_code == 0
         assert '"merged_at": "2026-05-28T12:00:00+08:00"' in result.output
-
 
     def test_pr_list_template_with_json_uses_template(self, runner, mock_client, mock_repo):
         mock_client.get.return_value = [


### PR DESCRIPTION
## Description

- Parse gh-compatible `gc pr list --search "is:merged merged:<after>..<before>"` qualifiers and map them to GitCode API `state=merged`, `merged_after`, and `merged_before` parameters.
- Expose gh-compatible `mergedAt` JSON output by normalizing GitCode's `merged_at` response field.
- Add unit coverage for merged-time search mapping and `mergedAt` output.

## Related Issue

Closes #127

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`PYTHONPATH=.worktrees/issue-127/src /Users/codeasier/.local/bin/pytest .worktrees/issue-127/tests/unit/commands/test_pr.py -q --no-cov`)
- [ ] Lint passes (`python -m ruff check src/ tests/`)
- [ ] Format passes (`python -m ruff format --check src/ tests/`)
- [ ] Type check passes (`python -m basedpyright src/`)
- [ ] Test coverage remains >= 90%

Additional validation:

- [x] Compile check passes (`PYTHONPATH=.worktrees/issue-127/src python -m compileall -q .worktrees/issue-127/src .worktrees/issue-127/tests`)

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation if needed (README, docstrings)
- [ ] My changes generate no new lint/type warnings
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide