### PR TITLE
Support PR comment line mapping

### DIFF
--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -81,6 +81,75 @@ def _extract_search_filters(
     return normalized_search, state, merged_after, merged_before
 
 
+def _advance_diff_line(
+    raw_line: str, old_line: int, new_line: int, target_line: int, target_side: str, position: int
+) -> tuple[int | None, int, int]:
+    prefix = raw_line[:1]
+    if prefix == "-":
+        return (position if target_side == "LEFT" and old_line == target_line else None), old_line + 1, new_line
+    if prefix == "+":
+        return (position if target_side == "RIGHT" and new_line == target_line else None), old_line, new_line + 1
+    matched = (target_side == "LEFT" and old_line == target_line) or (
+        target_side == "RIGHT" and new_line == target_line
+    )
+    return (position if matched else None), old_line + 1, new_line + 1
+
+
+def _diff_position_for_line(diff_text: str, path: str, line: int, side: str) -> int:
+    target_side = side.upper()
+    if target_side not in {"LEFT", "RIGHT"}:
+        raise click.UsageError("--side must be LEFT or RIGHT")
+
+    old_line = None
+    new_line = None
+    position = 0
+    in_target_file = False
+    saw_target_file = False
+
+    for raw_line in diff_text.splitlines():
+        if raw_line.startswith("diff --git "):
+            old_line = None
+            new_line = None
+            position = 0
+            in_target_file = False
+            continue
+        if raw_line.startswith("+++ b/"):
+            in_target_file = raw_line[6:] == path
+            saw_target_file = saw_target_file or in_target_file
+            continue
+        if not in_target_file:
+            continue
+        hunk = re.match(r"@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@", raw_line)
+        if hunk:
+            old_line = int(hunk.group(1))
+            new_line = int(hunk.group(2))
+            continue
+        if old_line is None or new_line is None or raw_line.startswith("\\"):
+            continue
+
+        position += 1
+        matched_position, old_line, new_line = _advance_diff_line(
+            raw_line, old_line, new_line, line, target_side, position
+        )
+        if matched_position is not None:
+            return matched_position
+
+    if not saw_target_file:
+        raise click.ClickException(f"Path '{path}' was not found in the pull request diff.")
+    raise click.ClickException(f"Line {line} on {target_side} side is not in the pull request diff.")
+
+
+def _resolve_comment_position_from_line(
+    service: PullRequestService, owner: str, repo: str, number: int, path: str | None, line: int | None, side: str
+) -> int | None:
+    if line is None:
+        return None
+    if path is None:
+        raise click.UsageError("--path is required when using --line")
+    diff_text = service.diff(owner, repo, number)
+    return _diff_position_for_line(diff_text, path, line, side)
+
+
 @click.group("pr", cls=GCSectionGroup, help="Work with GitCode pull requests.")
 def pr_group() -> None:
     pass
@@ -158,6 +227,10 @@ def pr_merge(
 @click.option("-w", "--web", is_flag=True, help="Open the pull request in the web browser.")
 @click.option("--path")
 @click.option("--position", type=int)
+@click.option("--line", type=int)
+@click.option("--side", default="RIGHT", show_default=True)
+@click.option("--commit-id")
+@click.option("--commit", "commit_id")
 @click.option("--yes", is_flag=True)
 @click.pass_context
 def pr_comment(
@@ -173,6 +246,9 @@ def pr_comment(
     web: bool,
     path: str | None,
     position: int | None,
+    line: int | None,
+    side: str,
+    commit_id: str | None,
     yes: bool,
 ) -> None:
     if create_if_none:
@@ -183,6 +259,10 @@ def pr_comment(
         _pending_gh_compat("pr comment --edit-last")
     if yes:
         _pending_gh_compat("pr comment --yes")
+    if commit_id:
+        raise click.ClickException("GitCode PR comments do not support selecting a commit for line comments.")
+    if line is not None and position is not None:
+        raise click.UsageError("--line cannot be used with --position")
     app = ctx.obj["app"]
     owner, repo = resolve_repo(repo_name or app.repo)
     service = PullRequestService(app.client())
@@ -195,7 +275,8 @@ def pr_comment(
         return
     body = get_body_from_options(body=body, body_file=body_file, editor=editor)
     body = prompt_if_missing(body, "Body")
-    item = service.comment(owner, repo, number, body=body, path=path, position=position)
+    resolved_position = position or _resolve_comment_position_from_line(service, owner, repo, number, path, line, side)
+    item = service.comment(owner, repo, number, body=body, path=path, position=resolved_position)
     safe_echo(str(item["id"]))
 
 

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -669,6 +669,58 @@ class TestPrMerge:
         assert result.exit_code == 0
         assert "123" in result.output
 
+    def test_pr_comment_maps_right_line_to_gitcode_position(self, runner, mock_client, mock_repo):
+        mock_client.request.return_value = """diff --git a/src/app.py b/src/app.py
+--- a/src/app.py
++++ b/src/app.py
+@@ -10,3 +10,4 @@
+ context
+-old
++new
++added
+"""
+        mock_client.post.return_value = {"id": 123}
+        result = runner.invoke(
+            main,
+            ["pr", "comment", "42", "--body", "hi", "--path", "src/app.py", "--line", "12"],
+        )
+        assert result.exit_code == 0
+        assert mock_client.post.call_args.kwargs["json"] == {"body": "hi", "path": "src/app.py", "position": 4}
+
+    def test_pr_comment_maps_left_line_to_gitcode_position(self, runner, mock_client, mock_repo):
+        mock_client.request.return_value = """diff --git a/src/app.py b/src/app.py
+--- a/src/app.py
++++ b/src/app.py
+@@ -10,3 +10,3 @@
+ context
+-old
++new
+ unchanged
+"""
+        mock_client.post.return_value = {"id": 123}
+        result = runner.invoke(
+            main,
+            ["pr", "comment", "42", "--body", "hi", "--path", "src/app.py", "--line", "11", "--side", "LEFT"],
+        )
+        assert result.exit_code == 0
+        assert mock_client.post.call_args.kwargs["json"] == {"body": "hi", "path": "src/app.py", "position": 2}
+
+    def test_pr_comment_line_requires_path(self, runner, mock_client, mock_repo):
+        result = runner.invoke(main, ["pr", "comment", "42", "--body", "hi", "--line", "12"])
+        assert result.exit_code != 0
+        assert "--path is required when using --line" in result.output
+        mock_client.request.assert_not_called()
+        mock_client.post.assert_not_called()
+
+    def test_pr_comment_rejects_commit_selection(self, runner, mock_client, mock_repo):
+        result = runner.invoke(
+            main,
+            ["pr", "comment", "42", "--body", "hi", "--path", "src/app.py", "--line", "12", "--commit-id", "abc"],
+        )
+        assert result.exit_code != 0
+        assert "do not support selecting a commit" in result.output
+        mock_client.post.assert_not_called()
+
     def test_pr_comment_without_identifier_uses_current_branch(self, runner, mock_client, mock_repo):
         mock_client.post.return_value = {"id": 123}
         with patch(


### PR DESCRIPTION
## Description

Adds gh-compatible PR line comment inputs for `gc pr comment` by resolving `--path`, `--line`, and `--side` against the PR diff and sending GitCode's existing `path` + `position` payload. Keeps `--path` + `--position` available for native GitCode usage and rejects commit selection because GitCode does not expose reliable commit-scoped line comment semantics here.

## Related Issue

Fixes #126

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`conda run -n gitcode-cli python -m pytest .worktrees/issue-126/tests/unit/ --cov=gitcode_cli --cov-report=xml --cov-fail-under=90`)
- [x] Lint passes (`conda run -n gitcode-cli python -m ruff check .worktrees/issue-126/src/ .worktrees/issue-126/tests/`)
- [x] Format passes (`conda run -n gitcode-cli python -m ruff format --check .worktrees/issue-126/src/ .worktrees/issue-126/tests/`)
- [x] Type check passes (`conda run -n gitcode-cli python -m basedpyright .worktrees/issue-126/src/`)
- [x] Test coverage remains >= 90% (92.40%)

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [x] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide