### PR TITLE
Fix PR list search and pagination

### DIFF
--- a/src/gitcode_cli/adapters/pulls.py
+++ b/src/gitcode_cli/adapters/pulls.py
@@ -13,6 +13,16 @@ def _normalize_multi_values(values: tuple[str, ...] | None) -> str | None:
     return ",".join(values)
 
 
+def _normalize_limit(limit: int | None) -> tuple[int, int | None]:
+    if limit is None:
+        return 30, 30
+    if limit < 0:
+        return 100, None
+    if limit == 0:
+        return 0, 0
+    return min(limit, 100), limit
+
+
 class PullRequestAdapter:
     def __init__(self, service: PullRequestService):
         self.service = service
@@ -42,15 +52,30 @@ class PullRequestAdapter:
             "draft": draft,
             "head": head,
             "labels": _normalize_multi_values(labels),
-            "search": search,
         }
+        if search is not None:
+            params["search"] = search
         if merged_after is not None:
             params["merged_after"] = merged_after
         if merged_before is not None:
             params["merged_before"] = merged_before
-        items = self.service.list(owner, repo, **params)
-        if limit is not None:
-            return items[:limit]
+
+        per_page, remaining = _normalize_limit(limit)
+        if remaining == 0:
+            return []
+
+        items = []
+        page = 1
+        while True:
+            page_items = self.service.list(owner, repo, **params, page=page, per_page=per_page)
+            if not page_items:
+                break
+            items.extend(page_items)
+            if remaining is not None and len(items) >= remaining:
+                return items[:remaining]
+            if len(page_items) < per_page:
+                break
+            page += 1
         return items
 
     def create_pr(

--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -74,9 +74,11 @@ def _extract_search_filters(
         merged_after = after
         merged_before = before
         remaining = remaining.replace(match.group(0), " ", 1)
-    if re.search(r"(?:^|\s)is:merged(?:\s|$)", search):
-        state = "merged"
-        remaining = re.sub(r"(?:^|\s)is:merged(?=\s|$)", " ", remaining)
+    for search_state in ("open", "closed", "merged"):
+        if re.search(rf"(?:^|\s)is:{search_state}(?:\s|$)", search):
+            state = search_state
+            remaining = re.sub(rf"(?:^|\s)is:{search_state}(?=\s|$)", " ", remaining)
+            break
     normalized_search = " ".join(remaining.split()) or None
     return normalized_search, state, merged_after, merged_before
 

--- a/tests/unit/adapters/test_pulls_adapter.py
+++ b/tests/unit/adapters/test_pulls_adapter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 
@@ -31,7 +31,7 @@ class TestPullRequestAdapter:
             draft=True,
             head="feature",
             labels=("bug", "docs"),
-            search="query",
+            search=None,
             limit=1,
         )
 
@@ -45,9 +45,111 @@ class TestPullRequestAdapter:
             draft=True,
             head="feature",
             labels="bug,docs",
-            search="query",
+            page=1,
+            per_page=1,
         )
         assert result == [{"number": 1}]
+
+    def test_list_prs_paginates_until_limit(self, adapter, service):
+        service.list.side_effect = [
+            [{"number": number} for number in range(1, 6)],
+            [{"number": number} for number in range(6, 11)],
+        ]
+
+        result = adapter.list_prs(
+            "owner",
+            "repo",
+            state="open",
+            author=None,
+            base=None,
+            assignee=None,
+            draft=None,
+            head=None,
+            labels=None,
+            search=None,
+            limit=5,
+        )
+
+        assert service.list.call_args_list == [
+            call(
+                "owner",
+                "repo",
+                state="open",
+                author=None,
+                base=None,
+                assignee=None,
+                draft=None,
+                head=None,
+                labels=None,
+                page=1,
+                per_page=5,
+            ),
+        ]
+        assert result == [{"number": number} for number in range(1, 6)]
+
+    def test_list_prs_fetches_all_pages_for_unlimited_limit(self, adapter, service):
+        service.list.side_effect = [
+            [{"number": number} for number in range(1, 101)],
+            [{"number": number} for number in range(101, 201)],
+            [{"number": 201}],
+        ]
+
+        result = adapter.list_prs(
+            "owner",
+            "repo",
+            state=None,
+            author=None,
+            base=None,
+            assignee=None,
+            draft=None,
+            head=None,
+            labels=None,
+            search=None,
+            limit=-1,
+        )
+
+        assert service.list.call_args_list == [
+            call(
+                "owner",
+                "repo",
+                state=None,
+                author=None,
+                base=None,
+                assignee=None,
+                draft=None,
+                head=None,
+                labels=None,
+                page=1,
+                per_page=100,
+            ),
+            call(
+                "owner",
+                "repo",
+                state=None,
+                author=None,
+                base=None,
+                assignee=None,
+                draft=None,
+                head=None,
+                labels=None,
+                page=2,
+                per_page=100,
+            ),
+            call(
+                "owner",
+                "repo",
+                state=None,
+                author=None,
+                base=None,
+                assignee=None,
+                draft=None,
+                head=None,
+                labels=None,
+                page=3,
+                per_page=100,
+            ),
+        ]
+        assert result == [{"number": number} for number in range(1, 202)]
 
     def test_create_pr_dry_run_returns_normalized_payload_without_service_call(self, adapter, service):
         result = adapter.create_pr(

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -88,6 +88,8 @@ class TestPrList:
                 "head": "feature-branch",
                 "labels": "bug",
                 "search": "search",
+                "page": 1,
+                "per_page": 1,
             },
         )
 
@@ -114,7 +116,8 @@ class TestPrList:
                 "draft": None,
                 "head": None,
                 "labels": "bug,docs",
-                "search": None,
+                "page": 1,
+                "per_page": 30,
             },
         )
 
@@ -171,9 +174,10 @@ class TestPrList:
                 "draft": None,
                 "head": None,
                 "labels": None,
-                "search": None,
                 "merged_after": "2026-05-28T14:00:00+08:00",
                 "merged_before": "2026-05-28T20:00:00+08:00",
+                "page": 1,
+                "per_page": 100,
             },
         )
         assert '"mergedAt": "2026-05-28T16:00:00+08:00"' in result.output
@@ -181,6 +185,8 @@ class TestPrList:
     @pytest.mark.parametrize(
         ("search", "expected_search", "expected_params"),
         [
+            ("is:open", None, {"state": "open"}),
+            ("is:closed", None, {"state": "closed"}),
             ("is:merged", None, {"state": "merged"}),
             ("merged:2026-05-28", None, {"merged_after": "2026-05-28", "merged_before": "2026-05-28"}),
             ("merged:>2026-05-28", None, {"merged_after": "2026-05-28"}),
@@ -208,7 +214,7 @@ class TestPrList:
         assert result.exit_code == 0
         params = mock_client.get.call_args.kwargs["params"]
         assert params | expected_params == params
-        assert params["search"] == expected_search
+        assert params.get("search") == expected_search
 
     def test_pr_list_merged_search_preserves_explicit_state_without_is_merged(self, runner, mock_client, mock_repo):
         result = runner.invoke(main, ["pr", "list", "--state", "all", "--search", "merged:>=2026-05-28"])


### PR DESCRIPTION
## Description

Fix `gc pr list` so gh-style `--search` state qualifiers like `is:open` and `is:closed` are translated into supported GitCode API state filters, and add pagination so `--limit -1` and larger result sets fetch complete PR lists instead of truncating at the first page.

## Related Issue

Closes #130

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation update
- [ ] CI/Build improvement

## How Has This Been Tested?

- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Format passes (`python -m ruff format --check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%

## Checklist

- [x] My code follows the project's coding style (ruff + black, line-length 120)
- [x] I have added tests that prove my fix/feature works
- [ ] I have updated the documentation if needed (README, docstrings)
- [x] My changes generate no new lint/type warnings
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide