### PR TITLE
Paginate gc issue list across API pages (#142)

### DIFF
--- a/src/gitcode_cli/adapters/issues.py
+++ b/src/gitcode_cli/adapters/issues.py
@@ -177,18 +177,35 @@ class IssueAdapter:
             if not current_login:
                 raise click.ClickException("failed to resolve @me: current user has no login")
             author = current_login
-        items = self.service.list(
-            owner,
-            repo,
-            state=state,
-            labels=_normalize_multi_values(labels),
-            creator=author,
-            assignee=assignee,
-            milestone=milestone,
-            mention=mention,
-            search=search,
-        )
-        if isinstance(items, list) and labels and len(labels) > 1:
+        params = {
+            "state": state,
+            "labels": _normalize_multi_values(labels),
+            "creator": author,
+            "assignee": assignee,
+            "milestone": milestone,
+            "mention": mention,
+            "search": search,
+        }
+        needs_and_filter = bool(labels) and len(labels) > 1
+        per_page = 100 if limit is None else min(limit, 100)
+        items: list[Any] = []
+        page = 1
+        while True:
+            page_items = _as_list(self.service.list(owner, repo, **params, page=page, per_page=per_page))
+            if not page_items:
+                break
+            items.extend(page_items)
+            if len(page_items) < per_page:
+                break
+            if limit is not None:
+                if needs_and_filter:
+                    matched = sum(1 for item in items if _matches_all_labels(item, labels))
+                else:
+                    matched = len(items)
+                if matched >= limit:
+                    break
+            page += 1
+        if needs_and_filter:
             items = [item for item in items if _matches_all_labels(item, labels)]
         if limit is not None:
             return items[:limit]

--- a/tests/unit/adapters/test_issue_adapter.py
+++ b/tests/unit/adapters/test_issue_adapter.py
@@ -49,6 +49,8 @@ class TestIssueAdapter:
             milestone="v1",
             mention="carol",
             search="query",
+            page=1,
+            per_page=1,
         )
         assert result == [{"number": "1", "labels": [{"name": "bug"}, {"name": "docs"}]}]
 
@@ -101,7 +103,159 @@ class TestIssueAdapter:
             milestone=None,
             mention=None,
             search=None,
+            page=1,
+            per_page=100,
         )
+
+    def test_list_issues_paginates_until_limit_met(self, adapter, service):
+        service.list.side_effect = [
+            [{"number": str(number)} for number in range(1, 101)],
+            [{"number": str(number)} for number in range(101, 201)],
+        ]
+
+        result = adapter.list_issues(
+            "owner",
+            "repo",
+            state="open",
+            labels=None,
+            author=None,
+            assignee=None,
+            milestone=None,
+            mention=None,
+            search=None,
+            limit=150,
+        )
+
+        assert service.list.call_args_list == [
+            call(
+                "owner",
+                "repo",
+                state="open",
+                labels=None,
+                creator=None,
+                assignee=None,
+                milestone=None,
+                mention=None,
+                search=None,
+                page=1,
+                per_page=100,
+            ),
+            call(
+                "owner",
+                "repo",
+                state="open",
+                labels=None,
+                creator=None,
+                assignee=None,
+                milestone=None,
+                mention=None,
+                search=None,
+                page=2,
+                per_page=100,
+            ),
+        ]
+        assert result == [{"number": str(number)} for number in range(1, 151)]
+
+    def test_list_issues_stops_on_short_page(self, adapter, service):
+        service.list.side_effect = [
+            [{"number": str(number)} for number in range(1, 101)],
+            [{"number": str(number)} for number in range(101, 138)],
+        ]
+
+        result = adapter.list_issues(
+            "owner",
+            "repo",
+            state="open",
+            labels=None,
+            author=None,
+            assignee=None,
+            milestone=None,
+            mention=None,
+            search=None,
+            limit=250,
+        )
+
+        assert service.list.call_count == 2
+        assert result == [{"number": str(number)} for number in range(1, 138)]
+
+    def test_list_issues_stops_on_empty_page(self, adapter, service):
+        service.list.side_effect = [
+            [{"number": str(number)} for number in range(1, 101)],
+            [],
+        ]
+
+        result = adapter.list_issues(
+            "owner",
+            "repo",
+            state="open",
+            labels=None,
+            author=None,
+            assignee=None,
+            milestone=None,
+            mention=None,
+            search=None,
+            limit=None,
+        )
+
+        assert service.list.call_count == 2
+        assert result == [{"number": str(number)} for number in range(1, 101)]
+
+    def test_list_issues_multi_label_limit_counts_matching_items(self, adapter, service):
+        service.list.side_effect = [
+            [
+                {"number": "1", "labels": [{"name": "bug"}, {"name": "docs"}]},
+                {"number": "2", "labels": [{"name": "bug"}]},
+                {"number": "3", "labels": [{"name": "bug"}]},
+            ],
+            [
+                {"number": "4", "labels": [{"name": "bug"}, {"name": "docs"}]},
+                {"number": "5", "labels": [{"name": "bug"}, {"name": "docs"}]},
+                {"number": "6", "labels": [{"name": "bug"}]},
+            ],
+        ]
+
+        result = adapter.list_issues(
+            "owner",
+            "repo",
+            state="open",
+            labels=("bug", "docs"),
+            author=None,
+            assignee=None,
+            milestone=None,
+            mention=None,
+            search=None,
+            limit=3,
+        )
+
+        assert service.list.call_args_list == [
+            call(
+                "owner",
+                "repo",
+                state="open",
+                labels="bug,docs",
+                creator=None,
+                assignee=None,
+                milestone=None,
+                mention=None,
+                search=None,
+                page=1,
+                per_page=3,
+            ),
+            call(
+                "owner",
+                "repo",
+                state="open",
+                labels="bug,docs",
+                creator=None,
+                assignee=None,
+                milestone=None,
+                mention=None,
+                search=None,
+                page=2,
+                per_page=3,
+            ),
+        ]
+        assert [item["number"] for item in result] == ["1", "4", "5"]
 
     def test_create_issue_normalizes_labels(self, adapter, service):
         service.list_labels.return_value = [{"name": "bug"}, {"name": "docs"}]

--- a/tests/unit/commands/test_issue.py
+++ b/tests/unit/commands/test_issue.py
@@ -92,8 +92,54 @@ class TestIssueList:
                 "search": "search",
                 "milestone": "v1",
                 "mention": "octocat",
+                "page": 1,
+                "per_page": 1,
             },
         )
+
+    def test_paginates_until_limit_met(self, runner, mock_client, mock_repo):
+        mock_client.get.side_effect = [
+            [{"number": str(number), "state": "open", "title": f"Issue {number}"} for number in range(1, 101)],
+            [{"number": str(number), "state": "open", "title": f"Issue {number}"} for number in range(101, 201)],
+        ]
+
+        result = runner.invoke(main, ["issue", "list", "-L", "150"])
+
+        assert result.exit_code == 0
+        assert mock_client.get.call_count == 2
+        assert mock_client.get.call_args_list == [
+            call(
+                "/repos/owner/repo/issues",
+                params={
+                    "state": None,
+                    "labels": None,
+                    "creator": None,
+                    "assignee": None,
+                    "milestone": None,
+                    "mention": None,
+                    "search": None,
+                    "page": 1,
+                    "per_page": 100,
+                },
+            ),
+            call(
+                "/repos/owner/repo/issues",
+                params={
+                    "state": None,
+                    "labels": None,
+                    "creator": None,
+                    "assignee": None,
+                    "milestone": None,
+                    "mention": None,
+                    "search": None,
+                    "page": 2,
+                    "per_page": 100,
+                },
+            ),
+        ]
+        assert "#1\topen\tIssue 1" in result.output
+        assert "#150\topen\tIssue 150" in result.output
+        assert "#151" not in result.output
 
     def test_web_opens_issues_page_without_fetching(self, runner, mock_client, mock_repo):
         with patch("gitcode_cli.commands.issue.open_in_browser") as mock_browser:
@@ -123,6 +169,8 @@ class TestIssueList:
                     "milestone": None,
                     "mention": None,
                     "search": None,
+                    "page": 1,
+                    "per_page": 30,
                 },
             ),
         ]


### PR DESCRIPTION
## Summary

Fixes #142. `gc issue list` previously made a single API request without `page`/`per_page`, so issues beyond the API default page (20, max 100) were unreachable regardless of `--limit`. This makes issue listing paginate consistently with `gc pr list` (`PullRequestAdapter.list_prs`).

## Changes

- `src/gitcode_cli/adapters/issues.py` — `IssueAdapter.list_issues()` now pages with `per_page = min(limit, 100)` (100 when no limit), incrementing `page` until `--limit` is met or a short/empty page arrives, then slices.
- Multi-label AND filtering stays client-side, but pagination now counts *matching* items so `--limit` still means matching issues even when pages contain non-matches.
- Non-list API responses are treated as an empty page (existing `_as_list` guard preserved).

## Out of scope (per issue review)

- Default TTY list output stays compact (no `body`); use `--json body` / `-t` for the body. Not a bug.
- `--limit -1` parity with `gc pr list` is left as a follow-up; issue list still requires `--limit >= 1`.

## Tests

- Updated 4 tests asserting the old single-request shape (command + adapter level).
- Added 5 regression tests: paginate until limit met, stop on short page, stop on empty page, multi-label limit semantics (adapter), end-to-end pagination (command).
- Full suite: 655 passed, coverage 92.31% (target 90%).
- `ruff check src tests` clean; `basedpyright` 0 errors; pre-commit hooks all pass.