### PR TITLE
docs: add architecture-oriented AGENTS.md hierarchy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md
+
+Guidance for coding agents working in this repository. Language: the repo's primary docs are English (`README.md`, `docs/en/`); `README.zh-CN.md`, `docs/zh-CN/`, and `ROADMAP.md` are Chinese translations/counterparts.
+
+## What this repository is
+
+`pygitcode` is a single Python package (src-layout) that provides the `gc` / `gitcode` CLI for GitCode (`https://api.gitcode.com/api/v5/`), modeled after GitHub's `gh` CLI. Runtime dependencies are only `click` and `httpx`. Python >= 3.9.
+
+## Architecture and data flow
+
+Request flow is a strict four-layer pipeline. Each layer is tested in isolation by a mirroring test layer (see `tests/AGENTS.md`):
+
+```
+commands/*.py (Click UX, flag parsing, output shaping)
+    → adapters/*.py (translate gh semantics into GitCode-compatible calls)
+        → services/*.py (thin REST path/method wrappers)
+            → client.py (httpx; injects access_token query param)
+```
+
+Two planes sit alongside that pipeline:
+
+- `src/gitcode_cli/compat/` — the authoritative gc ↔ gh compatibility registry (metadata plane; also a routing allowlist for the gh proxy).
+- `src/gitcode_cli/gh_proxy.py` + `src/gitcode_cli/commands/setup.py` — the optional `gh` dispatcher installed into user directories (`gc setup gh-proxy`).
+
+See `src/gitcode_cli/AGENTS.md` for per-module responsibilities and invariants.
+
+## Entry points and registration
+
+| Entry point | Where defined | Notes |
+|---|---|---|
+| `gc`, `gitcode` console scripts | `pyproject.toml` `[project.scripts]` → `gitcode_cli.cli:main` | Both names are the same `main` group; `gitcode` exists because `gc` collides with PowerShell's `Get-Content`. |
+| `python -m gitcode_cli.cli` | `__main__` guard in `src/gitcode_cli/cli.py` | This is how the gh proxy execs the real CLI (`gh_proxy.dispatch`). |
+| `python -m gitcode_cli.gh_proxy` | `src/gitcode_cli/gh_proxy.py` | The installed `gh` shim execs this. |
+| Command group registration | `main.add_command(...)` calls in `src/gitcode_cli/cli.py` | A new group must also be added to the `set_gc_help(...)` section lists on `main` (CORE/ADDITIONAL) or help output will be inconsistent. |
+
+## Cross-cutting runtime behavior
+
+- Token resolution order (`src/gitcode_cli/config.py`): `--token` flag > `GC_TOKEN` env var > `~/.config/gc/config.json` (written by `gc auth login`). Missing token raises `ConfigError`.
+- Repo resolution (`src/gitcode_cli/repo.py`): explicit `-R [HOST/]OWNER/REPO` or `git remote get-url origin` (HTTPS, `ssh://`, and SCP-style SSH URLs are all parsed).
+- All `GCError` subclasses are caught once in `_GCMainGroup.invoke` (`src/gitcode_cli/cli.py`) and become `error: ...` on stderr with exit code 1. Command code raises typed errors; it does not print-and-exit itself.
+- Every HTTP request carries the token as an `access_token` query parameter (GitCode's auth model — not a header).
+
+## Build, run, test boundaries
+
+| Task | Command | Evidence |
+|---|---|---|
+| Dev install | `pip install -e ".[dev]"` | `docs/en/development.md`, `.github/CONTRIBUTING.md` |
+| Full test suite (unit + contracts) | `python -m pytest tests` | `pyproject.toml` `[tool.pytest.ini_options]` `testpaths = ["tests"]`; `tests/README.md` shows the maintainers' conda variant `conda run -n gitcode-cli python -m pytest tests` |
+| Unit tests only | `python -m pytest tests/unit/` | This is what CI and pre-commit run — contract tests do **not** run in CI |
+| Lint / format | `python -m ruff check src/ tests/` and `python -m ruff format src/ tests/` | `ci.yml` lint job; config in `pyproject.toml` (line length 120, py39 target) |
+| Type check | `python -m basedpyright src/` | `ci.yml` typecheck job; `[tool.basedpyright]` includes only `src` |
+| All checks at once | `pre-commit run --all-files` | `.pre-commit-config.yaml` (ruff, basedpyright, pytest unit with coverage gate) |
+
+- pytest `addopts` always enable `--cov=gitcode_cli --cov-fail-under=90` plus an HTML report, so any pytest run writes `.coverage` and `htmlcov/` (both gitignored) and fails below 90% coverage.
+- CI (`ci.yml`) runs the unit suite on Python 3.9–3.13, plus separate lint and typecheck jobs, on `main` pushes and PRs.
+
+## Release lifecycle
+
+- Version is dynamic (`pyproject.toml` reads `gitcode_cli.__version__`, which is `0.0.0-dev` in-tree). Do not hand-bump it for releases: `.github/workflows/publish.yml` rewrites it from `v*` tags at build time, publishes to PyPI, and creates a GitHub Release.
+- A `v*` tag fails to publish unless `CHANGELOG.md` contains a non-empty `## [x.y.z]` section for that version — the workflow validates it.
+- `dev<commit-hash>` tags build `{base}.devYYYYMMDD+{hash}` versions to TestPyPI (`publish-dev.yml`), deriving the base from the latest `v*` tag.
+
+## Known misleading artifacts
+
+- `CLAUDE.md` at the repo root is stale (it claims `tests/` is empty and predates `adapters/`, `compat/`, and the gh proxy). Trust `tests/README.md`, `docs/en/`, and these AGENTS.md files instead.
+
+## Child guides
+
+| Scope | File | What it owns |
+|---|---|---|
+| Python package | [src/gitcode_cli/AGENTS.md](src/gitcode_cli/AGENTS.md) | Per-module map, layer invariants, gh-proxy subsystem lifecycle, platform-dependent behavior |
+| Compat registry | [src/gitcode_cli/compat/AGENTS.md](src/gitcode_cli/compat/AGENTS.md) | The gc ↔ gh status registry and its test-enforced lockstep contract |
+| Adapter layer | [src/gitcode_cli/adapters/AGENTS.md](src/gitcode_cli/adapters/AGENTS.md) | gh-semantics translation, capability keys, `AdapterActionResult` protocol, pagination |
+| Tests | [tests/AGENTS.md](tests/AGENTS.md) | Test layers, focusing commands, fixtures, coverage gate, conftest contracts |

--- a/src/gitcode_cli/AGENTS.md
+++ b/src/gitcode_cli/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md — `gitcode_cli` package
+
+Parent scope: repository root ([../../AGENTS.md](../../AGENTS.md)) — install/test/lint/release commands live there and are not repeated here. This guide covers the single installable package behind the `gc` / `gitcode` console scripts.
+
+## Module map
+
+| Module | Owns | Notable invariants |
+|---|---|---|
+| `cli.py` | Click root group `main`; `--repo/-R`, hidden `--token`; `version` and `completion` commands; group registration | Catch-all `GCError` → stderr + exit 1 lives in `_GCMainGroup.invoke`. On win32, stdout/stderr are reconfigured to UTF-8 for TTYs. New groups must be registered here **and** in the `set_gc_help` section lists. |
+| `commands/` | Click UX per domain: `auth.py`, `issue.py` (10 subcommands), `pr.py` (13 subcommands), `compat.py`, `setup.py` | Commands resolve repo, build `Service(app_ctx.client())` + adapter, delegate, then shape output via `formatters.output_result`. Unimplemented-but-recognized flags raise `_pending_gh_compat("<key>")`; GitCode-impossible flags raise `unsupported("<CAPABILITY_KEY>")`. Both literals are test-policed (see the compat guide). |
+| `adapters/` | gh-semantics → GitCode translation | See [adapters/AGENTS.md](adapters/AGENTS.md). |
+| `services/` | Thin REST wrappers: `issues.py`, `pulls.py`, `users.py` | Path shapes are contract-tested against `tests/fixtures/gitcode-api-contracts/raw/`. Issue create/update post to `/repos/{owner}/issues` with `repo` in the JSON body (not the path) — unlike every other endpoint. `PullRequestService.list_comments` paginates internally at `per_page=100`; `diff()` requests `text/plain`. |
+| `client.py` | `GitCodeClient`: httpx wrapper, `BASE_URL = "https://api.gitcode.com/api/v5/"` | Merges `access_token` into every request's query params, drops `None` param values; 30s timeout; 401 → `APIError` with a "run gc auth login" hint; other ≥400 → `APIError`; httpx transport errors → `NetworkError`. |
+| `config.py` | Token persistence: `~/.config/gc/config.json` | Tests monkeypatch `CONFIG_DIR`/`CONFIG_PATH` module attributes (see `tests/conftest.py` `tmp_config_dir`). |
+| `context.py` | `AppContext` dataclass (`token`, `repo`) with `client()` factory | Command tests replace `AppContext.client` via the `mock_app_context` fixture — keep the factory a single method. |
+| `repo.py` | Repo string / remote URL parsing | `parse_repo_with_host` accepts `OWNER/REPO` and `HOST/OWNER/REPO`; host detection here feeds gh-proxy routing. |
+| `errors.py` | `GCError` → `ConfigError`, `AuthError`, `RepoResolutionError`, `APIError(status_code)`, `NetworkError` | Only `GCError` subtypes get the graceful one-place exit handling in `cli.py`. |
+| `formatters.py` | Output shaping: `--json` field filtering, `-q` jq, `-t` Go-template subset, list/detail renderers | `apply_jq` needs either the Python `jq` module or a `jq` binary on PATH — neither is a package dependency, so `--jq` can fail at runtime by design. Templates support only `{{.a.b}}`, `{{range .}}`, and `{{"\n"}}`. |
+| `helptext.py` | gh-style grouped help rendering (`GCSectionGroup`, `set_gc_help` metadata) | Help text comes from attributes like `gc_command_sections`/`gc_examples` set via `set_gc_help`, not from docstrings alone. |
+| `utils.py` | git subprocess helpers, issue/PR URL+number identifier parsing, `safe_echo` (encoding-safe) | `resolve_pr_arg` accepts number, URL, or branch (branch triggers an API lookup). |
+| `cli_compat.py` | Shared command helpers: `--body`/`--body-file`/`--editor` resolution and `--fill[-first|-verbose]` git-log extraction | Despite the name, this is not the gh-compat registry — that is `compat/`. |
+| `gh_proxy.py` + `commands/setup.py` | Optional `gh` dispatcher subsystem | See below. |
+| `compat/` | gh-compatibility registry | See [compat/AGENTS.md](compat/AGENTS.md). |
+
+## Layering rules (what must change together)
+
+Adding or changing a user-facing flag typically touches four places in one PR:
+
+1. The Click option in `commands/` (parsing, validation, help).
+2. The translation in `adapters/` (new capability keys go in `adapters/capabilities.py` `CAPABILITY_MESSAGES`).
+3. The registry row in `compat/entries.py` with the matching `pending_key` / `unsupported_key`.
+4. Tests in `tests/unit/commands/` and/or `tests/unit/adapters/`.
+
+`tests/unit/compat/test_registry_consistency.py` fails the build if any of these drift apart, so a partial change will not pass CI even if the new code itself works.
+
+Output changes (`--json` field lists, `-t` templates, human formats) should extend the `gc_json_fields` metadata consumed by `helptext.py` and the normalization helpers in `commands/issue.py` / `commands/pr.py` (e.g. `_normalize_pr_fields` back-fills `mergedAt` from `merged_at`, `_normalize_closing_issue` maps `OPENED` → `OPEN` state).
+
+## gh dispatcher subsystem (`gh_proxy.py`, `commands/setup.py`)
+
+`gc setup gh-proxy` installs a `gh` shim next to nothing else — it never touches a real `gh` installation:
+
+- Shim location: `~/.local/share/gc/gh-proxy/gh` (`%LOCALAPPDATA%\gc\gh-proxy\gh.cmd` on Windows), overridable with `GC_GH_PROXY_DIR`. The shim sets `GC_GH_SHIM` and execs `python -m gitcode_cli.gh_proxy`.
+- Files without the managed marker (`Generated by gc setup gh-proxy`, `# >>> gc gh-proxy >>>`, `<!-- Generated by gc setup gh-proxy -->`) are never overwritten or removed — preserve this fail-safe when touching install/uninstall code.
+- Routing (`gh_proxy.select_target`): `GC_GH_TARGET=gitcode|github` > host in explicit `-R`/`--repo` > `origin` host > default `github`. `gitcode.com` and `ssh.gitcode.com` are GitCode by default; `GC_GITCODE_HOSTS` adds more. `GC_REAL_GH` locates the native CLI when PATH discovery fails.
+- GitCode-bound commands are fail-closed: `validate_gitcode_command` only accepts subcommands present (and not `not_in_cli`) in the compat registry — a command missing from the registry is an error, never a silent GitHub fallback.
+- Dispatch to `gc` uses `os.execve` on POSIX (argument/stream/exit-status preserving) and `subprocess.call` on Windows, and exports `GC_GH_PROXY_ACTIVE=1` (consumed by `auth status` to print a proxy notice).
+- `--configure` additionally writes a managed PATH block into the detected shell profile (`GC_GH_SHELL_PROFILE` override; zsh → `~/.zshenv`, bash → `~/.bash_profile` on macOS / `~/.bashrc` elsewhere, fish, PowerShell) and appends `gh-proxy-instructions.md` to the `instructions` array of `~/.config/opencode/opencode.json` (`GC_OPENCODE_CONFIG` override).
+
+## Platform-dependent behavior
+
+- Windows: use `gitcode` rather than `gc` (PowerShell alias collision); stdout/stderr are force-reconfigured to UTF-8 (`cli.py`); the shim is a `.cmd` batch file; proxy exec goes through `subprocess.call` instead of `execve`.
+- `commands/setup.py` picks the shell profile file by `$SHELL` and `sys.platform` — changes here need coverage for more than one platform path.

--- a/src/gitcode_cli/adapters/AGENTS.md
+++ b/src/gitcode_cli/adapters/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md — `adapters/` (gh-semantics translation layer)
+
+Parent scope: the `gitcode_cli` package ([../AGENTS.md](../AGENTS.md)). Build/test commands are documented at the repository root.
+
+## What this directory owns
+
+Translation between what a `gh` user asked for and what the GitCode API can actually do. Adapters call `services/` exclusively; they never build HTTP requests themselves and never print output. Commands in `../commands/` call adapters and branch on the returned `AdapterActionResult`.
+
+| File | Role |
+|---|---|
+| `base.py` | `AdapterActionResult` dataclass — the layer's return protocol (below). |
+| `capabilities.py` | `CAPABILITY_MESSAGES` — every user-visible "GitCode cannot do X" message, keyed by constants like `ISSUE_LIST_APP` or `PR_EDIT_BASE`, plus `unsupported(key)` which builds the `ClickException`. |
+| `issues.py` | `IssueAdapter(service, user_service=None)` — list (with pagination and client-side multi-label AND filtering), create (label existence check, milestone title→number resolution), close/reopen (idempotency checks against current state), comment history (edit/delete last own comment), edit (label/assignee merge logic), status (approximation), develop (browser no-op). |
+| `pulls.py` | `PullRequestAdapter(service)` — list (pagination + `--limit` normalization), create (incl. `--dry-run` payload echo), merge, review (see degradation below), edit, status (approximation). |
+
+## The `AdapterActionResult` protocol
+
+`item` / `items` (payload), `message` (result classification), `warning`, and the flags `degraded` / `approximated`. Commands consume the classification strings literally, so treat them as an API:
+
+- `manage_comment_history` returns `"deleted"` / `"created"` / `"edited"` — `commands/issue.py` branches on `"deleted"` and `"created"`.
+- `close_issue` returns `"already_closed"` / `"already_closed_commented"` / `"closed"`; `reopen_issue` returns `"already_open"` / `"reopened"`.
+- `degraded=True` from `review_pr` makes `gc pr review --request-changes` **fail** with the capability message after posting a plain PR comment (GitCode has no request-changes review) — the comment is still posted, then `commands/pr.py` raises.
+- `approximated=True` (`issue status`, `pr status`) means output prints with a semantics caveat; adapters must carry the matching `CAPABILITY_MESSAGES` text, not ad-hoc strings.
+
+## Capability keys and the registry
+
+Adding an unsupported behavior requires three coordinated additions: the `unsupported("<KEY>")` guard in `../commands/`, the `KEY` in `CAPABILITY_MESSAGES` here, and a registry row with that `unsupported_key` in `../compat/entries.py`. `tests/unit/compat/test_registry_consistency.py` enforces all three exist together; see [../compat/AGENTS.md](../compat/AGENTS.md).
+
+## Conventions worth preserving
+
+- **Pagination lives here, not in services.** Loops fetch `per_page=100` (or `min(limit, 100)` for issue lists) until a short page or the requested limit is reached. `_normalize_limit` in `pulls.py` defines the `--limit` semantics commands rely on: `None` → default 30, negative → fetch everything at 100/page, `0` → empty result, positive → capped page size with exact truncation.
+- **`@me` resolution** (`issues.py`) needs `user_service`; adapters that receive `None` must raise a `ClickException` explaining the lookup is unavailable rather than silently skipping the filter.
+- **Client-side filtering** is the escape hatch for API gaps: multi-label AND semantics (GitCode's `labels` param is OR), assignee removal, and label merge on edit all re-read current state via `service.get(...)` and compute the full replacement payload.
+- Ownership checks (`_find_last_owned_comment`) compare the current user's login against comment authors; when the login cannot be established they raise the `ISSUE_COMMENT_OWNERSHIP_UNVERIFIABLE` capability error instead of guessing — keep that refusal behavior.
+
+## Tests
+
+`tests/unit/adapters/` tests each adapter against mock services; `tests/unit/commands/test_issue_adapter_boundary.py` and `test_pr_adapter_boundary.py` pin the command→adapter delegation surface (argument names and adapter calls), so renaming an adapter method parameter ripples into those files.

--- a/src/gitcode_cli/compat/AGENTS.md
+++ b/src/gitcode_cli/compat/AGENTS.md
@@ -1,0 +1,44 @@
+# AGENTS.md — `compat/` (gh-compatibility registry)
+
+Parent scope: the `gitcode_cli` package ([../AGENTS.md](../AGENTS.md)). Build/test commands are documented at the repository root.
+
+## What this directory owns
+
+The authoritative registry of `gc` ↔ `gh` compatibility status, replacing the hand-maintained table from GitCode issue #68. It is metadata, not behavior: nothing here talks to the network or parses argv (with one exception — `gh_proxy` uses it as an allowlist, see below).
+
+| File | Role |
+|---|---|
+| `_types.py` | `CompatStatus` enum (`implemented` / `pending` / `unsupported` / `not_in_cli`) and the frozen `CompatEntry` dataclass (`command`, `flag`, `status`, `note`, `pending_key`, `unsupported_key`, `gc_extension`, `aliases`). `flag is None` means the entry describes a whole subcommand. |
+| `entries.py` | `ENTRIES` — the data, one `_e(...)` call per row, transcribed from issue #68. This is the only file you normally edit. |
+| `registry.py` | Frozen aggregation/API: `iter_entries(groups=, statuses=)`, `statistics()`, `render_markdown_report()`. Do not mutate `_ENTRIES` — it is a `Final` tuple by design. |
+
+## Status semantics
+
+| Status | Runtime meaning |
+|---|---|
+| `implemented` | Click option exists and matches `gh` semantics (or a documented approximation). |
+| `pending` | Option parses, but invoking it raises `_pending_gh_compat("<pending_key>")`. |
+| `unsupported` | Option parses, but invoking it raises `unsupported("<unsupported_key>")`; the key must exist in `adapters/capabilities.py` `CAPABILITY_MESSAGES`. |
+| `not_in_cli` | `gh` has it, `gc` does not — Click rejects the flag outright. |
+
+## The lockstep contract (test-enforced)
+
+`tests/unit/compat/test_registry_consistency.py` fails when any of these drift:
+
+- every `pending` entry's `pending_key` appears as a literal `_pending_gh_compat("<key>")` call in `src/gitcode_cli/commands/*.py`, and vice versa;
+- every `unsupported` entry's `unsupported_key` exists in `CAPABILITY_MESSAGES` and is raised via `unsupported(...)` in the command layer;
+- every `implemented`/`pending`/`unsupported` flag is actually registered with Click, and every `not_in_cli` flag is absent;
+- no duplicate `(command, flag)` pairs; at least 100 entries total (guards against accidental wipes).
+
+Practical consequence: change `entries.py` in the same PR as the corresponding command/adapter code. A registry-only edit or a code-only edit will fail the unit suite.
+
+## Consumers
+
+| Consumer | How it uses the registry |
+|---|---|
+| `gc compat report [--stdout]`, `gc compat stats`, `gc compat list [--all] [--status ...]` (`commands/compat.py`) | Render the matrix as Markdown (issue #68 layout), JSON counts, or filtered rows. `gc compat report --stdout > COMPATIBILITY.md` regenerates the document — never hand-edit rendered output. |
+| `gh_proxy.validate_gitcode_command` (`../gh_proxy.py`) | Fail-closed allowlist: a GitCode-targeted `gh` invocation is accepted only if its subcommand is registered here with a status other than `not_in_cli`. |
+| `tests/unit/compat/test_compat_report.py` | Rendering/statistics checks. |
+| `tests/unit/commands/test_cli_gh_compat.py` | Cross-checks the Click command tree against `tests/fixtures/gh-cli-compat/command_baseline.json` (a `gh --help` dump of gh 2.89.0) using `coverage.json` exclusion lists. |
+
+When adding a top-level command group beyond `auth`/`issue`/`pr`, note that `render_markdown_report()` and `statistics()` hard-code the `("auth", "issue", "pr")` iteration — extend that tuple or the new group will silently vanish from reports, and `gh_proxy` will refuse its subcommands.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md — `tests/`
+
+Parent scope: repository root ([../AGENTS.md](../AGENTS.md)) for install commands and CI wiring. `README.md` in this directory explains the intent of the split; this guide adds the boundaries agents need when changing code.
+
+## Layout mirrors the source layers
+
+| Directory / file | Exercises | Typical focus command |
+|---|---|---|
+| `unit/test_cli.py`, `unit/test_cli_compat.py` | Root Click group, option wiring, helper functions | `python -m pytest tests/unit/test_cli.py` |
+| `unit/commands/` | Command UX: parsing, guards, exit behavior, delegation to adapters | `python -m pytest tests/unit/commands/test_pr.py` |
+| `unit/adapters/` | gh→GitCode translation, degradation, pagination | `python -m pytest tests/unit/adapters` |
+| `unit/services/` | REST path/method/payload construction | `python -m pytest tests/unit/services` |
+| `unit/compat/` | Registry consistency and report rendering | `python -m pytest tests/unit/compat` |
+| `contracts/` | Service calls vs extracted GitCode API docs (fixtures below) | `python -m pytest tests/contracts` |
+| Root-level `unit/test_*.py` | One file per core module: `test_client.py` (respx-mocked HTTP), `test_config.py`, `test_repo.py`, `test_gh_proxy.py`, `test_utils.py`, `test_formatters.py`, `test_errors.py`, `test_context.py` | `python -m pytest tests/unit/test_gh_proxy.py` |
+
+`tests/README.md` and `docs/en/development.md` also show the maintainers' conda form (`conda run -n gitcode-cli python -m pytest ...`); CI and `.github/CONTRIBUTING.md` use the plain form. They are equivalent entry points.
+
+## Boundaries and gotchas
+
+- **CI never runs `tests/contracts/`.** Both `ci.yml` and the pre-commit pytest hook invoke `tests/unit/` only. The contract suite executes when you run the full suite (`python -m pytest tests`, via `testpaths` in `pyproject.toml`) — run it explicitly before touching `services/`.
+- **Coverage gate is always on.** `pyproject.toml` `addopts` apply `--cov=gitcode_cli --cov-fail-under=90` (plus an HTML report writing `htmlcov/`, gitignored) to every pytest invocation, including single-file focus runs. CI adds `--cov-report=xml` and keeps the same 90% floor on the unit suite only.
+- **`pythonpath = ["src"]`** is set for pytest, so tests import `gitcode_cli` without installing the package.
+- **No test talks to the real API.** Command tests patch `AppContext.client` wholesale via the `mock_app_context` fixture in `conftest.py`; `test_client.py` uses `respx`; adapter/boundary tests use `MagicMock` services. Keep new command tests on `mock_app_context` (or `CliRunner` with it) rather than introducing real HTTP.
+
+## Fixtures
+
+| Path | Content | Consumed by |
+|---|---|---|
+| `fixtures/gitcode-api-contracts/raw/Issues/`, `fixtures/gitcode-api-contracts/raw/Pull Requests/` | Extracted GitCode API v5 endpoint docs (one JSON per method+path). Paths are formatted with `owner`/`repo` and compared after stripping the `/api/v5` prefix. | `contracts/test_gitcode_api_contracts.py` |
+| `fixtures/gh-cli-compat/command_baseline.json` | Full `gh --help` command/flag tree of gh 2.89.0 | `unit/commands/test_cli_gh_compat.py` (drift detection between the `gc` Click tree and the `gh` baseline) |
+| `fixtures/gh-cli-compat/coverage.json` | Per-command excluded flags and tracked subcommand selections for the baseline diff | same file; it fails if `coverage.json` references commands absent from the baseline |
+
+`conftest.py` also provides shared data fixtures (`mock_issue_data`, `mock_pr_data`, list fixtures) and `tmp_config_dir`, which redirects token config to a temp dir by monkeypatching the `CONFIG_DIR`/`CONFIG_PATH` module attributes in `gitcode_cli.config` — new config-touching tests must use it to avoid reading the developer's real `~/.config/gc/config.json`.
+
+## Where regressions usually land
+
+The layer of a failure identifies the layer to fix: argument/exit-code problems in `unit/commands/` point at `src/gitcode_cli/commands/`; semantic drift (wrong filters, degraded behavior) in `unit/adapters/` points at `src/gitcode_cli/adapters/`; path/payload mismatches in `unit/services/` or `contracts/` point at `src/gitcode_cli/services/`; registry lockstep failures in `unit/compat/test_registry_consistency.py` mean `src/gitcode_cli/compat/entries.py` and the command code disagree (see [../src/gitcode_cli/compat/AGENTS.md](../src/gitcode_cli/compat/AGENTS.md)).


### PR DESCRIPTION
## What this adds

An evidence-based hierarchy of `AGENTS.md` guides derived from static analysis of the codebase (no builds or tests were executed):

| File | Scope |
|---|---|
| `AGENTS.md` | Repo overview, four-layer data flow, entry points and registration points, build/run/test/lint boundaries, release lifecycle, navigation index |
| `src/gitcode_cli/AGENTS.md` | Package module map, layering rules (what must change together), gh-proxy dispatcher subsystem lifecycle, platform-dependent behavior |
| `src/gitcode_cli/compat/AGENTS.md` | The gc ↔ gh compatibility registry: status taxonomy, test-enforced lockstep contract, consumers |
| `src/gitcode_cli/adapters/AGENTS.md` | Adapter layer: `AdapterActionResult` protocol, capability keys, pagination/limit semantics, degradation behavior |
| `tests/AGENTS.md` | Test layers, focus commands, fixtures (gh 2.89.0 baseline, GitCode API contracts), coverage gate, conftest contracts |

## Key architecture facts documented

- Request flow: `commands/` → `adapters/` → `services/` → `client.py` (httpx, `access_token` query param, base `https://api.gitcode.com/api/v5/`), with the compat registry and gh-proxy as parallel planes.
- Entry points: `gc`/`gitcode` console scripts → `gitcode_cli.cli:main`; `python -m gitcode_cli.gh_proxy` for the dispatcher shim; new command groups must also be listed in `set_gc_help` sections on `main`.
- Lockstep contract: flag changes must update `commands/`, `adapters/capabilities.py`, `compat/entries.py`, and tests together — enforced by `tests/unit/compat/test_registry_consistency.py`.
- Test boundaries: CI and pre-commit run `tests/unit/` only (90% coverage floor via pytest `addopts`); `tests/contracts/` runs only in full local suite runs.
- Release lifecycle: version is rewritten from `v*`/`dev*` tags by publish workflows; a `v*` tag requires a matching non-empty `CHANGELOG.md` section or publishing fails.
- Noted that root `CLAUDE.md` is stale (predates `adapters/`, `compat/`, gh-proxy, and the test suite).

## Validation

- `validate_agents.py`: **Checked 5 AGENTS.md files: 0 error(s), 0 warning(s)** (all relative links resolve).
- `git diff --check`: clean.

## Note

`.gitignore` excludes `**/AGENTS.md`, so the five files were added with `git add -f`. Once tracked, gitignore no longer applies to them, but removing that pattern in a follow-up would make intent explicit.