### PR TITLE
Map pr view JSON commit OIDs from GitCode SHAs

### DIFF
--- a/src/gitcode_cli/commands/auth.py
+++ b/src/gitcode_cli/commands/auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 
 import click
 
@@ -22,7 +23,7 @@ def auth_group() -> None:
 @click.option("--with-token", is_flag=True, help="Read token from stdin.")
 def auth_login(with_token: bool) -> None:
     if with_token:
-        token = click.get_text_stream("stdin").read().strip()
+        token = sys.stdin.read().strip()
         if not token:
             raise click.ClickException("No token provided on stdin.")
     else:

--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -81,6 +81,13 @@ def _pr_ref_name(value: object) -> object:
     return value.get("ref") if isinstance(value, dict) else value
 
 
+def _pr_ref_oid(value: object) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    sha = value.get("sha")
+    return sha if isinstance(sha, str) and sha else None
+
+
 def _normalize_pr_view_fields(item: dict) -> dict:
     result = _normalize_pr_fields(item)
     assignees = item.get("assignees")
@@ -91,8 +98,10 @@ def _normalize_pr_view_fields(item: dict) -> dict:
                 [_normalize_pr_actor(assignee) for assignee in assignees] if isinstance(assignees, list) else assignees
             ),
             "baseRefName": item.get("baseRefName") or _pr_ref_name(item.get("base")),
+            "baseRefOid": item.get("baseRefOid") or _pr_ref_oid(item.get("base")),
             "createdAt": item.get("createdAt") or item.get("created_at"),
             "headRefName": item.get("headRefName") or _pr_ref_name(item.get("head")),
+            "headRefOid": item.get("headRefOid") or _pr_ref_oid(item.get("head")),
             "updatedAt": item.get("updatedAt") or item.get("updated_at"),
             "url": item.get("html_url") or item.get("url"),
         }
@@ -970,11 +979,13 @@ set_gc_help(
         "author",
         "assignees",
         "baseRefName",
+        "baseRefOid",
         "body",
         "closingIssuesReferences",
         "comments",
         "createdAt",
         "headRefName",
+        "headRefOid",
         "labels",
         "mergedAt",
         "number",

--- a/src/gitcode_cli/commands/pr.py
+++ b/src/gitcode_cli/commands/pr.py
@@ -39,10 +39,25 @@ def _pr_merged_at(item: dict) -> str | None:
     return str(value) if value else None
 
 
+def _pr_ref_name(value: object) -> object:
+    return value.get("ref") if isinstance(value, dict) else value
+
+
+def _pr_ref_oid(value: object) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    sha = value.get("sha")
+    return sha if isinstance(sha, str) and sha else None
+
+
 def _normalize_pr_fields(item: dict) -> dict:
     result = dict(item)
     if "mergedAt" not in result:
         result["mergedAt"] = _pr_merged_at(item)
+    result["baseRefName"] = item.get("baseRefName") or _pr_ref_name(item.get("base"))
+    result["baseRefOid"] = item.get("baseRefOid") or _pr_ref_oid(item.get("base"))
+    result["headRefName"] = item.get("headRefName") or _pr_ref_name(item.get("head"))
+    result["headRefOid"] = item.get("headRefOid") or _pr_ref_oid(item.get("head"))
     return result
 
 
@@ -77,17 +92,6 @@ def _normalize_pr_actor(value: object) -> object:
     }
 
 
-def _pr_ref_name(value: object) -> object:
-    return value.get("ref") if isinstance(value, dict) else value
-
-
-def _pr_ref_oid(value: object) -> str | None:
-    if not isinstance(value, dict):
-        return None
-    sha = value.get("sha")
-    return sha if isinstance(sha, str) and sha else None
-
-
 def _normalize_pr_view_fields(item: dict) -> dict:
     result = _normalize_pr_fields(item)
     assignees = item.get("assignees")
@@ -97,11 +101,7 @@ def _normalize_pr_view_fields(item: dict) -> dict:
             "assignees": (
                 [_normalize_pr_actor(assignee) for assignee in assignees] if isinstance(assignees, list) else assignees
             ),
-            "baseRefName": item.get("baseRefName") or _pr_ref_name(item.get("base")),
-            "baseRefOid": item.get("baseRefOid") or _pr_ref_oid(item.get("base")),
             "createdAt": item.get("createdAt") or item.get("created_at"),
-            "headRefName": item.get("headRefName") or _pr_ref_name(item.get("head")),
-            "headRefOid": item.get("headRefOid") or _pr_ref_oid(item.get("head")),
             "updatedAt": item.get("updatedAt") or item.get("updated_at"),
             "url": item.get("html_url") or item.get("url"),
         }
@@ -953,9 +953,11 @@ set_gc_help(
         "author",
         "assignees",
         "baseRefName",
+        "baseRefOid",
         "body",
         "createdAt",
         "headRefName",
+        "headRefOid",
         "labels",
         "mergedAt",
         "number",

--- a/src/gitcode_cli/helptext.py
+++ b/src/gitcode_cli/helptext.py
@@ -100,11 +100,16 @@ def _display_command_path(ctx: click.Context) -> str:
 
 
 def _argument_metavar(param: click.Argument, ctx: click.Context) -> str:
-    make_metavar = param.make_metavar
-    try:
-        return make_metavar(ctx)
-    except TypeError:
-        return str(getattr(param, "metavar", None) or param.name or "")
+    make_metavar = getattr(param, "make_metavar", None)
+    if callable(make_metavar):
+        try:
+            return str(make_metavar(ctx))
+        except TypeError:
+            try:
+                return str(make_metavar())
+            except TypeError:
+                pass
+    return str(getattr(param, "metavar", None) or param.name or "")
 
 
 def _command_sections(command: click.Group) -> list[tuple[str, list[tuple[str, str]]]]:

--- a/src/gitcode_cli/helptext.py
+++ b/src/gitcode_cli/helptext.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import textwrap
 from typing import Any
 
@@ -100,16 +101,17 @@ def _display_command_path(ctx: click.Context) -> str:
 
 
 def _argument_metavar(param: click.Argument, ctx: click.Context) -> str:
+    fallback = str(getattr(param, "metavar", None) or param.name or "")
     make_metavar = getattr(param, "make_metavar", None)
-    if callable(make_metavar):
-        try:
-            return str(make_metavar(ctx))
-        except TypeError:
-            try:
-                return str(make_metavar())
-            except TypeError:
-                pass
-    return str(getattr(param, "metavar", None) or param.name or "")
+    if not callable(make_metavar):
+        return fallback
+    try:
+        signature = inspect.signature(make_metavar)
+    except (TypeError, ValueError):
+        return fallback
+    if signature.parameters:
+        return str(make_metavar(ctx))
+    return str(make_metavar())
 
 
 def _command_sections(command: click.Group) -> list[tuple[str, list[tuple[str, str]]]]:

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -136,6 +136,35 @@ class TestPrList:
         assert '"number": 1' in result.output
         assert '"title": "First PR"' in result.output
 
+    def test_pr_list_json_maps_ref_names_and_oids(self, runner, mock_client, mock_repo):
+        mock_client.get.return_value = [
+            {
+                "number": 1,
+                "base": {"ref": "main", "sha": "aaa111base"},
+                "head": {"ref": "feature", "sha": "bbb222head"},
+            },
+        ]
+        result = runner.invoke(
+            main,
+            ["pr", "list", "--json", "number,baseRefName,headRefName,baseRefOid,headRefOid"],
+        )
+        assert result.exit_code == 0
+        assert json.loads(result.output) == [
+            {
+                "number": 1,
+                "baseRefName": "main",
+                "headRefName": "feature",
+                "baseRefOid": "aaa111base",
+                "headRefOid": "bbb222head",
+            }
+        ]
+
+    def test_pr_list_help_lists_ref_oid_fields(self, runner):
+        result = runner.invoke(main, ["pr", "list", "--help"])
+        assert result.exit_code == 0
+        assert "baseRefOid" in result.output
+        assert "headRefOid" in result.output
+
     def test_pr_list_json_includes_merged_at_alias(self, runner, mock_client, mock_repo):
         mock_client.get.return_value = [
             {"number": 1, "merged_at": "2026-05-28T16:00:00+08:00"},

--- a/tests/unit/commands/test_pr.py
+++ b/tests/unit/commands/test_pr.py
@@ -324,8 +324,8 @@ class TestPrList:
                 "body": "PR body",
                 "user": {"id": "7", "login": "alice", "name": "Alice"},
                 "assignees": [{"id": "8", "login": "bob", "name": "Bob"}],
-                "base": {"ref": "main"},
-                "head": {"ref": "feature"},
+                "base": {"ref": "main", "sha": "aaa111base"},
+                "head": {"ref": "feature", "sha": "bbb222head"},
                 "labels": [{"id": 1, "name": "bug", "color": "ff0000"}],
                 "created_at": "2026-08-01T10:00:00+08:00",
                 "updated_at": "2026-08-02T10:00:00+08:00",
@@ -337,8 +337,8 @@ class TestPrList:
         ]
 
         fields = (
-            "author,assignees,baseRefName,body,comments,createdAt,headRefName,labels,mergedAt,number,state,"
-            "title,updatedAt,url"
+            "author,assignees,baseRefName,baseRefOid,body,comments,createdAt,headRefName,headRefOid,labels,"
+            "mergedAt,number,state,title,updatedAt,url"
         )
         result = runner.invoke(main, ["pr", "view", "42", "--json", fields])
 
@@ -347,10 +347,12 @@ class TestPrList:
             "author": {"id": "7", "is_bot": False, "login": "alice", "name": "Alice"},
             "assignees": [{"id": "8", "is_bot": False, "login": "bob", "name": "Bob"}],
             "baseRefName": "main",
+            "baseRefOid": "aaa111base",
             "body": "PR body",
             "comments": [{"id": 9, "body": "Looks good", "user": {"login": "carol"}}],
             "createdAt": "2026-08-01T10:00:00+08:00",
             "headRefName": "feature",
+            "headRefOid": "bbb222head",
             "labels": [{"id": 1, "name": "bug", "color": "ff0000"}],
             "mergedAt": "2026-08-02T09:00:00+08:00",
             "number": 42,
@@ -372,11 +374,48 @@ class TestPrList:
         assert result.exit_code == 0
         mock_client.get.assert_called_once_with("/repos/owner/repo/pulls/42")
 
+    def test_pr_view_json_maps_ref_oids_for_same_branch_pr(self, runner, mock_client, mock_repo):
+        mock_client.get.return_value = {
+            "number": 76,
+            "state": "open",
+            "base": {"ref": "master", "sha": "43e5b9d1ec0f18fbe97cab721d194ab9d25919bb"},
+            "head": {"ref": "master", "sha": "974db1ff6e10881fbdd3504ffec867c28a7b6bb1"},
+        }
+
+        result = runner.invoke(
+            main,
+            ["pr", "view", "76", "--json", "baseRefOid,headRefOid,baseRefName,headRefName,number,state"],
+        )
+
+        assert result.exit_code == 0
+        assert json.loads(result.output) == {
+            "baseRefOid": "43e5b9d1ec0f18fbe97cab721d194ab9d25919bb",
+            "headRefOid": "974db1ff6e10881fbdd3504ffec867c28a7b6bb1",
+            "baseRefName": "master",
+            "headRefName": "master",
+            "number": 76,
+            "state": "OPEN",
+        }
+
+    def test_pr_view_json_treats_empty_ref_sha_as_missing(self, runner, mock_client, mock_repo):
+        mock_client.get.return_value = {
+            "number": 76,
+            "base": {"ref": "master", "sha": ""},
+            "head": {"ref": "feature"},
+        }
+
+        result = runner.invoke(main, ["pr", "view", "76", "--json", "baseRefOid,headRefOid"])
+
+        assert result.exit_code == 0
+        assert json.loads(result.output) == {"baseRefOid": None, "headRefOid": None}
+
     def test_pr_view_help_lists_closing_issue_references(self, runner):
         result = runner.invoke(main, ["pr", "view", "--help"])
 
         assert result.exit_code == 0
         assert "closingIssuesReferences" in result.output
+        assert "baseRefOid" in result.output
+        assert "headRefOid" in result.output
 
     def test_pr_view_without_identifier_uses_current_branch(self, runner, mock_client, mock_repo):
         mock_client.get.side_effect = [

--- a/tests/unit/test_helptext.py
+++ b/tests/unit/test_helptext.py
@@ -1,0 +1,62 @@
+"""Tests for gitcode_cli.helptext helpers."""
+
+from __future__ import annotations
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from gitcode_cli.cli import main
+from gitcode_cli.helptext import _argument_metavar
+
+
+class TestArgumentMetavar:
+    def test_uses_ctx_when_make_metavar_accepts_context(self):
+        param = click.Argument(["identifier"], required=False)
+        ctx = click.Context(click.Command("view"))
+
+        assert _argument_metavar(param, ctx) == "[IDENTIFIER]"
+
+    def test_uses_no_arg_make_metavar_when_signature_is_empty(self):
+        param = click.Argument(["identifier"])
+        param.make_metavar = lambda: "IDENT"  # type: ignore[method-assign]
+        ctx = click.Context(click.Command("view"))
+
+        assert _argument_metavar(param, ctx) == "IDENT"
+
+    def test_falls_back_when_make_metavar_is_missing(self):
+        param = click.Argument(["identifier"])
+        param.make_metavar = None  # type: ignore[assignment]
+        ctx = click.Context(click.Command("view"))
+
+        assert _argument_metavar(param, ctx) == "identifier"
+
+    def test_falls_back_when_signature_cannot_be_inspected(self, monkeypatch):
+        param = click.Argument(["identifier"])
+        ctx = click.Context(click.Command("view"))
+
+        def boom(_obj: object) -> object:
+            raise TypeError("no signature")
+
+        monkeypatch.setattr("gitcode_cli.helptext.inspect.signature", boom)
+        assert _argument_metavar(param, ctx) == "identifier"
+
+    def test_propagates_type_error_from_make_metavar_body(self):
+        param = click.Argument(["identifier"])
+
+        def boom(ctx: click.Context) -> str:
+            raise TypeError("internal metavar failure")
+
+        param.make_metavar = boom  # type: ignore[method-assign]
+        ctx = click.Context(click.Command("view"))
+
+        with pytest.raises(TypeError, match="internal metavar failure"):
+            _argument_metavar(param, ctx)
+
+    def test_pr_view_help_usage_renders_identifier_metavar(self):
+        result = CliRunner().invoke(main, ["pr", "view", "--help"])
+
+        assert result.exit_code == 0
+        assert "USAGE\n  gc pr view [IDENTIFIER] [flags]" in result.output
+        assert "baseRefOid" in result.output
+        assert "headRefOid" in result.output


### PR DESCRIPTION
## Summary
- Map GitCode `base.sha` / `head.sha` to `baseRefOid` / `headRefOid` in `gc pr view --json` for every PR, including same-branch PRs.
- Document both fields in `gc pr view --help` JSON FIELDS so downstream tools can check out the PR head.
- Treat an empty SHA as missing (`null`), and satisfy the local `basedpyright` hook for Click `make_metavar` compatibility.

Fixes #147

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Test plan
- [x] Unit tests pass (`python -m pytest tests/unit/`)
- [x] Lint passes (`python -m ruff check src/ tests/`)
- [x] Type check passes (`python -m basedpyright src/`)
- [x] Test coverage remains >= 90%
- [ ] `gc pr view https://gitcode.com/Ascend/mscommreport/pull/76 --json baseRefOid,headRefOid,baseRefName,headRefName,number,state` returns distinct commit OIDs instead of `null`

## How Has This Been Tested?
- Added regression coverage for same-branch PRs, empty SHAs, advertised field mapping, and help text.
- Full suite: 657 passed, 92.32% coverage.